### PR TITLE
HH-30380 show original Content-Type and -Disposition on debug page, but replace it in actual output

### DIFF
--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -263,7 +263,7 @@ class PageHandler(tornado.web.RequestHandler):
 
         tornado.web.RequestHandler.finish(self, chunk)
 
-    def flush(self, include_footers=False):
+    def flush(self, include_footers=False, **kwargs):
         orig_write_buffer = self._write_buffer
         try:
             # if debug_mode is on: ignore any output we intended to write
@@ -310,8 +310,7 @@ class PageHandler(tornado.web.RequestHandler):
             self.log.debug('Couldnt write debug info')
             self._write_buffer = orig_write_buffer
 
-        tornado.web.RequestHandler.flush(self, include_footers=False)
-
+        tornado.web.RequestHandler.flush(self, include_footers=False, **kwargs)
         self.log.request_finish_hook()
 
     def get_page(self):

--- a/frontik/testing/service_mock.py
+++ b/frontik/testing/service_mock.py
@@ -180,7 +180,7 @@ class ExpectingHandler(object):
 
         self._handler = self.app(tornado_application, self.request, )
         self._handler.http_client = TestHttpClient(self)
-        self._handler.get_error_html = lambda handler, exception : None
+        self._handler.get_error_html = lambda *args, **kwargs: None
 
         def flush(include_footers=False, callback=None):
             if callback:


### PR DESCRIPTION
По смыслу изменения в коммите https://github.com/hhru/frontik/commit/1773e24aca720c622b47c6beec4ea183ff86a9f6
