### PR TITLE
HH-42490 use unicode chars when debugging xml & json responses

### DIFF
--- a/frontik/handler_debug.py
+++ b/frontik/handler_debug.py
@@ -193,11 +193,11 @@ def _exception_to_xml(exc_info, log=debug_log):
 
 
 def _pretty_print_xml(node):
-    return etree.tostring(node, pretty_print=True)
+    return etree.tostring(node, pretty_print=True, encoding=unicode)
 
 
 def _pretty_print_json(node):
-    return json.dumps(node, sort_keys=True, indent=4)
+    return json.dumps(node, sort_keys=True, indent=4, ensure_ascii=False)
 
 
 class DebugLogBulkHandler(object):


### PR DESCRIPTION
В замен не верно названной https://github.com/hhru/frontik/pull/106
