### PR TITLE
HH-45022 override check_xsrf_cookie method of PageHandler

### DIFF
--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -603,3 +603,8 @@ class PageHandler(tornado.web.RequestHandler):
 
     def set_template(self, filename):
         return self.json_producer.set_template(filename)
+
+    # TODO: Will be removed
+
+    def check_xsrf_cookie(self):
+        pass


### PR DESCRIPTION
Поскольку `frontik` приложения пока что используют один и тот же `frontik.cfg` необходимо переопределить метод `check_xsrf_cookie`, чтобы убрать проверку `xsrf` токенов в контроллерах.

https://jira.hh.ru/browse/HH-45030
