### PR TITLE
HH-47074 new stages logging

### DIFF
--- a/frontik/debug/debug-css.xsl
+++ b/frontik/debug/debug-css.xsl
@@ -19,6 +19,20 @@
                 word-break: break-all;
             }
 
+            .timeline {
+                position: absolute;
+                height: 100%;
+                background: #94b24d;
+                border-left: 1px solid green;
+                border-right: 1px solid green;
+                box-sizing: border-box;
+                opacity: 0.1;
+            }
+                .timeline_debug {
+                    border-left: none;
+                    background: #4d94b2;
+                }
+
             .timebar {
                 width: 100%;
                 margin-bottom: -1.4em;
@@ -29,14 +43,14 @@
                     vertical-align: middle;
                 }
                 .timebar__head {
-                    border-left: 1px solid green;
-                    border-right: 1px solid green;
-                    background-color: #94b24d;
-                    border-bottom: 1px solid #94b24d;
-                    opacity: 0.5;
                     display: block;
                     width: 0;
                     height: 1.4em;
+                    background-color: #94b24d;
+                    border-left: 1px solid green;
+                    border-right: 1px solid green;
+                    box-sizing: border-box;
+                    opacity: 0.5;
                 }
                     .timebar__head_error {
                         background-color: red;
@@ -46,12 +60,12 @@
                 top: 0;
                 height: 100%;
                 width: 100%;
+                margin-left: -20px;
+                margin-right: -20px;
                 white-space: nowrap;
             }
 
             .entry {
-                padding-left: 20px;
-                padding-right: 20px;
                 margin-bottom: 4px;
                 word-break: break-all;
                 position: relative;
@@ -61,8 +75,8 @@
                 }
                     .entry.entry_expandable:before {
                         float: left;
+                        position: absolute;
                         width: 20px;
-                        margin-left: -20px;
                         padding: 3px 0;
                         content: "▹";
                         text-align: center;
@@ -71,6 +85,7 @@
                 .entry_title {
                     font-size: 1.2em;
                     margin: 0.5em 0;
+                    margin-left: 20px;
                 }
                 .entry__head {
                     display: block;
@@ -82,6 +97,7 @@
                         display: inline-block;
                         position: relative;
                         padding: 3px 0;
+                        padding-left: 20px;
                         vertical-align: bottom;
                     }
                     .entry__head__level {
@@ -91,6 +107,7 @@
                     .entry__head__message {
                         display: inline-block;
                         padding: 2px 0;
+                        padding-left: 20px;
                         white-space: pre-wrap;
                     }
                 .entry__switcher {
@@ -103,12 +120,48 @@
             .headers{
             }
 
+            .line {
+                height: 12px;
+                margin-bottom: 12px;
+                text-align: center;
+                border-bottom: 1px solid #eee;
+            }
+                .line__bar {
+                    position: absolute;
+                    height: 0;
+                    margin-top: 10px;
+                    border-bottom: 4px solid #94b24d;
+                    opacity: 0.5;
+                }
+                    .line__bar_error {
+                        border-color: #c00;
+                    }
+                    .line__bar_warning {
+                        border-color: #E80;
+                    }
+                    .line__bar_info {
+                        border-color: #060;
+                    }
+                    .line__bar_debug {
+                        border-color: #00B;
+                    }
+                .line__label {
+                    position: relative;
+                    padding: 0 3px;
+                    font-size: 0.9em;
+                    line-height: 24px;
+                    background: white;
+                    border-radius: 2px;
+                }
+
             .details-expander {
                 display: none;
             }
             .details {
                 display: none;
                 padding-bottom: 8px;
+                padding-left: 20px;
+                padding-right: 20px;
                 position: relative;
             }
                 .m-details_visible,
@@ -193,21 +246,26 @@
                         color: #c00;
                     }
             .exception {
+                padding-left: 20px;
                 color: #c00;
             }
 
             .iframe {
                 width: 100%;
                 height: 500px;
+                margin-top: 5px;
                 background: #fff;
                 border: 1px solid #ccc;
-                margin-top: 5px;
-                box-shadow: 1px 1px 8px #aaacca;
+                box-sizing: border-box;
             }
 
             .debug-inherited {
+                position: relative;
                 margin: 10px 0;
-                border: 1px solid #ccc;
+                margin-left: -20px;
+                margin-right: -20px;
+                border-top: 1px solid #ccc;
+                border-bottom: 1px solid #ccc;
                 background: #fff;
             }
 

--- a/frontik/handler_debug.py
+++ b/frontik/handler_debug.py
@@ -73,7 +73,7 @@ def response_to_xml(response):
             E.effective_url(response.effective_url),
             E.error(str(response.error)),
             E.size(str(len(response.body)) if response.body is not None else '0'),
-            E.request_time(str(int(response.request_time * 1000))),
+            E.request_time(_format_number(response.request_time * 1000)),
             _headers_to_xml(response.headers),
             time_info,
         )
@@ -105,18 +105,16 @@ def request_to_xml(request):
     try:
         request = E.request(
             body,
+            E.start_time(_format_number(request.start_time)),
             E.connect_timeout(str(request.connect_timeout)),
+            E.request_timeout(str(request.request_timeout)),
             E.follow_redirects(str(request.follow_redirects)),
             E.max_redirects(str(request.max_redirects)),
             E.method(request.method),
-            E.request_timeout(str(request.request_timeout)),
-            _params_to_xml(request.url),
             E.url(request.url),
+            _params_to_xml(request.url),
             _headers_to_xml(request.headers),
             _cookies_to_xml(request.headers),
-            E.meta(
-                E.start_time(str(request.start_time))
-            ),
             E.curl(
                 request_to_curl_string(request)
             )


### PR DESCRIPTION
1) Прогрессбары времени запросов теперь рисуются точнее
2) Появились прогрессбары для стейджей
3) Во вложенном дебаге отображается общий таймлайн (если сравнить с временем запроса, то можно понять, сколько было потрачено на сетевое взаимодействие)
4) Вложенный дебаг разворачивается на всю ширину
5) Во вложенном дебаге убрано дублирование (информация о запросе и ответе, которая шла после вложенного дебага и перед телом ответа, на самом деле, дублируется в General request/response info в самом вложенном дебаге)

![screenshot from 2014-10-16 17 19 52](https://cloud.githubusercontent.com/assets/1271476/4662997/7d905ab6-5537-11e4-8661-3b3ae4ff6753.png)
