### PR TITLE
HH-48945 debugging auth by header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ frontik.egg-info/
 *.pid
 .coverage*
 .tox/
+/tests/temp/
 
 # OS X junk
 .AppleDouble

--- a/frontik/auth.py
+++ b/frontik/auth.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+import httplib
+
+DEBUG_AUTH_HEADER_NAME = 'Frontik-Debug-Auth'
 
 
 def passed_basic_auth(handler, login, passwd):
@@ -12,3 +15,21 @@ def passed_basic_auth(handler, login, passwd):
         given_login, _, given_passwd = decoded_value.partition(':')
         return login == given_login and passwd == given_passwd
     return False
+
+
+def check_debug_auth(handler, login, password):
+    """
+    :type handler: tornado.web.RequestHandler
+    :return: None or tuple(http_code, headers)
+    """
+    header_name = DEBUG_AUTH_HEADER_NAME
+    debug_auth_header = handler.request.headers.get(header_name)
+    if debug_auth_header is not None:
+        debug_access = (debug_auth_header == '{}:{}'.format(login, password))
+        if not debug_access:
+            return httplib.UNAUTHORIZED, {'WWW-Authenticate': '{}-Header realm="Secure Area"'.format(header_name)}
+    else:
+        debug_access = passed_basic_auth(handler, login, password)
+        if not debug_access:
+            return httplib.UNAUTHORIZED, {'WWW-Authenticate': 'Basic realm="Secure Area"'}
+    return None

--- a/frontik/auth.py
+++ b/frontik/auth.py
@@ -3,9 +3,12 @@
 
 def passed_basic_auth(handler, login, passwd):
     auth_header = handler.request.headers.get('Authorization')
-
-    if auth_header:
+    if auth_header and auth_header.startswith('Basic '):
         method, auth_b64 = auth_header.split(' ')
-        given_login, _, given_passwd = auth_b64.decode('base64').partition(':')
+        try:
+            decoded_value = auth_b64.decode('base64')
+        except ValueError:
+            return False
+        given_login, _, given_passwd = decoded_value.partition(':')
         return login == given_login and passwd == given_passwd
     return False

--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -112,7 +112,7 @@ class BaseHandler(tornado.web.RequestHandler):
         self.xml = self.xml_producer  # deprecated synonym
         self.doc = self.xml_producer.doc
 
-        if self.get_argument('nopost', None) is not None:
+        if frontik.util.get_cookie_or_url_param_value(self, 'nopost') is not None:
             self.require_debug_access()
             self.apply_postprocessor = False
             self.log.debug('apply_postprocessor = False due to "nopost" argument')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,7 @@
 # coding=utf-8
+import os.path
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(__file__))
 
 
 def tearDownModule():

--- a/tests/instances.py
+++ b/tests/instances.py
@@ -67,7 +67,7 @@ class FrontikTestInstance(object):
         if not self.port:
             self.start()
 
-        url = 'http://localhost:{port}/{page}{notpl}'.format(
+        url = 'http://127.0.0.1:{port}/{page}{notpl}'.format(
             port=self.port,
             page=page.format(port=self.port),
             notpl=('?' if '?' not in page else '&') + 'notpl' if notpl else ''

--- a/tests/projects/frontik_debug.cfg
+++ b/tests/projects/frontik_debug.cfg
@@ -1,4 +1,4 @@
-host = '0.0.0.0'
+host = '127.0.0.1'
 pidfile_template = './frontik.%(port)s.pid'
 daemonize = False
 

--- a/tests/projects/frontik_debug.cfg
+++ b/tests/projects/frontik_debug.cfg
@@ -8,3 +8,4 @@ logfile = './frontik_test.log'
 loglevel = 'debug'
 suppressed_loggers = ['tornado.curl_httpclient', 'urllib3']
 stderr_log = False
+warn_no_jobs = False

--- a/tests/projects/frontik_non_debug.cfg
+++ b/tests/projects/frontik_non_debug.cfg
@@ -1,4 +1,4 @@
-host = '0.0.0.0'
+host = '127.0.0.1'
 pidfile_template = './frontik.%(port)s.pid'
 daemonize = False
 

--- a/tests/projects/frontik_non_debug.cfg
+++ b/tests/projects/frontik_non_debug.cfg
@@ -14,3 +14,4 @@ suppressed_loggers = ['tornado.curl_httpclient', 'urllib3']
 stderr_log = False
 
 handlers_count = 5
+warn_no_jobs = False

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,8 @@ import unittest
 from .instances import frontik_broken_app
 
 
-class TestApp(unittest.TestCase):
+class TestAppTestCase(unittest.TestCase):
+
     def test_broken_app(self):
-        self.assertRaises(AssertionError, frontik_broken_app.get_page, '')
+        with self.assertRaises(AssertionError):
+            frontik_broken_app.get_page('')

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -193,7 +193,7 @@ class DebugTestCase(unittest.TestCase):
             self.assertEqual('Frontik-Debug-Auth-Header realm="Secure Area"', response.headers['Www-Authenticate'])
 
     def test_debug_by_cookie(self):
-        for param in ('debug', 'noxsl', 'notpl'):  # FIXME: nopost?
+        for param in ('debug', 'noxsl', 'notpl', 'nopost'):
             self.assertDebugResponseCode(page='app/simple_xml',
                                          headers={'Cookie': '{}=true'.format(param)},
                                          expected_code=httplib.UNAUTHORIZED)

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import base64
+import httplib
 import unittest
 
 from tornado.escape import to_unicode
@@ -11,6 +12,10 @@ from .instances import frontik_non_debug
 
 
 class TestDebug(unittest.TestCase):
+
+    def setUp(self):
+        self.debug_basic_auth = 'Basic {}'.format(base64.encodestring('user:god'))
+
     def test_curl_string_get(self):
         request = make_get_request(
             'http://test.com/path',
@@ -51,7 +56,7 @@ class TestDebug(unittest.TestCase):
 
     def test_complex_debug_page(self):
         response = frontik_non_debug.get_page(
-            'app/debug?debug', headers={'Authorization': 'Basic {}'.format(base64.encodestring('user:god'))}
+            'app/debug?debug', headers={'Authorization': self.debug_basic_auth}
         )
 
         self.assertEquals(response.status_code, 200)
@@ -121,3 +126,48 @@ class TestDebug(unittest.TestCase):
 
         for msg in assert_not_found:
             self.assertNotIn(msg, response.content)
+
+    def assertDebugResponseCode(self, page, expected_code, headers=None):
+        response = frontik_non_debug.get_page(page, headers=headers)
+        self.assertEqual(
+            response.status_code,
+            expected_code
+        )
+        return response
+
+    def test_debug_by_basic_auth(self):
+        for param in ('debug', 'nopost', 'noxsl', 'notpl'):
+            response = self.assertDebugResponseCode(page='app/simple_xml?{}'.format(param),
+                                                    expected_code=httplib.UNAUTHORIZED)
+            self.assertIn('Www-Authenticate', response.headers)
+            self.assertRegexpMatches(response.headers['Www-Authenticate'], 'Basic realm="[^"]+"')
+
+            self.assertDebugResponseCode(page='app/simple_xml?{}'.format(param),
+                                         headers={'Authorization': self.debug_basic_auth},
+                                         expected_code=httplib.OK)
+
+    def test_debug_by_basic_auth_with_wrong_header(self):
+        for value in ('Token user:god',
+                      'Bearer abcdfe0123456789',
+                      'Basic',
+                      'Basic ',
+                      'Basic ScrewYou',
+                      'Basic {}'.format(base64.encodestring(':')),
+                      'Basic {}'.format(base64.encodestring('')),
+                      'Basic {}'.format(base64.encodestring('not:pass')),
+                      'BASIC {}'.format(base64.encodestring('user:god'))):
+            self.assertDebugResponseCode(page='app/simple_xml?debug',
+                                         headers={'Authorization': value},
+                                         expected_code=httplib.UNAUTHORIZED)
+
+    def test_debug_by_cookie(self):
+        for param in ('debug', 'noxsl', 'notpl'):  # FIXME: nopost?
+            self.assertDebugResponseCode(page='app/simple_xml',
+                                         headers={'Cookie': '{}=true'.format(param)},
+                                         expected_code=httplib.UNAUTHORIZED)
+            self.assertDebugResponseCode(page='app/simple_xml',
+                                         headers={
+                                             'Cookie': '{}=true;'.format(param),
+                                             'Authorization': self.debug_basic_auth
+                                         },
+                                         expected_code=httplib.OK)

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,0 +1,30 @@
+# _*_ coding: utf-8 _*_
+import unittest
+import socket
+import httplib
+import sys
+
+from . import instances
+
+
+class TestingInfrastructureTestCase(unittest.TestCase):
+
+    def test_bind_127_0_0_1(self):
+        success = False
+        for port in xrange(9000, 10000):
+            try:
+                sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                sock.bind(('127.0.0.1', port))
+                sock.close()
+                success = True
+                break
+            except:
+                continue
+        self.assertTrue(success, 'Unable to bind 127.0.0.1 on ports 9000-9999')
+
+    def test_load_page_from_test_instances(self):
+        for instance in (instances.frontik_test_app,
+                         instances.frontik_non_debug,
+                         instances.frontik_re_app):
+            sys.stderr.write('Check test instance for app "{}"\n'.format(instance.app))
+            self.assertEquals(instance.get_page('status').status_code, httplib.OK)

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -9,7 +9,7 @@ from . import PROJECT_ROOT
 
 
 class TestPep8(unittest.TestCase):
-    CHECKED_FILES = ('frontik', 'tests', 'setup.py')
+    CHECKED_PATHS = ('frontik', 'tests', 'examples', 'setup.py', 'frontik-test')
 
     def test_pep8(self):
         pep8style = pep8.StyleGuide(
@@ -17,5 +17,5 @@ class TestPep8(unittest.TestCase):
             show_source=True,
             max_line_length=120
         )
-        result = pep8style.check_files(map(partial(os.path.join, PROJECT_ROOT), TestPep8.CHECKED_FILES))
+        result = pep8style.check_files(map(partial(os.path.join, PROJECT_ROOT), TestPep8.CHECKED_PATHS))
         self.assertEqual(result.total_errors, 0, 'Pep8 found code style errors or warnings')

--- a/tests/test_pep8.py
+++ b/tests/test_pep8.py
@@ -1,8 +1,11 @@
 # coding=utf-8
-
+from functools import partial
+import os.path
 import unittest
 
 import pep8
+
+from . import PROJECT_ROOT
 
 
 class TestPep8(unittest.TestCase):
@@ -14,6 +17,5 @@ class TestPep8(unittest.TestCase):
             show_source=True,
             max_line_length=120
         )
-
-        result = pep8style.check_files(TestPep8.CHECKED_FILES)
+        result = pep8style.check_files(map(partial(os.path.join, PROJECT_ROOT), TestPep8.CHECKED_FILES))
         self.assertEqual(result.total_errors, 0, 'Pep8 found code style errors or warnings')


### PR DESCRIPTION
Теперь отладка возможна отправкой заголовка `Frontik-Debug-Auth: login:pass`.

Также пофиксил:
- при битом basic auth падала 500-ка (+ добавил тестов на это)

Также значительно пришлось поменять метод запуска test приложений:
- учёт текущего python exec (поддержка venv и нестандартных python версий)
- bind на `127.0.0.1`, вместо `localhost`. Иначе при наличии активированного в системе ipv6 стека, frontik стартует на `::1` при резолвинге `localhost`. Как победить это другим образом, например, резолвить форсированно ipv4 я не нашёл.
- при запуске/остановки сервера логи и pid'ы сыпятся в спец папку /tests/temp (это очень помогло с отладкой проблем)

В тестах доработано:
- теперь тесты будут работать в os x и в venv
- использование в тестах абсолютных путей
- отдельный TestCase тестирующий инфраструктуру тестирования, пригодится для отладки проблем на CI/CD системах

Вопросы на обсудить:
- почему nopost не берётся из куки, нужно ли это пофиксить?
- нужна ли настройка доступных методов авторизации? Мне кажется нет, почему описал в задаче HH-48945
- запуск приложения для тестирования и bind `localhost`.
- переименование пакета тестов на `frontik_tests`