### PR TITLE
HH-51161 fix make_qs with unicode param keys

### DIFF
--- a/frontik/util.py
+++ b/frontik/util.py
@@ -23,13 +23,14 @@ def _encode(s):
 
 def make_qs(query_args):
     kv_pairs = []
-    for (key, val) in query_args.iteritems():
+    for key, val in query_args.iteritems():
         if val is not None:
+            encoded_key = _encode(key)
             if isinstance(val, (set, frozenset, list, tuple)):
                 for v in val:
-                    kv_pairs.append((key, _encode(v)))
+                    kv_pairs.append((encoded_key, _encode(v)))
             else:
-                kv_pairs.append((key, _encode(val)))
+                kv_pairs.append((encoded_key, _encode(val)))
 
     qs = urlencode(kv_pairs)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-
+from collections import OrderedDict
 import unittest
 
 from frontik.util import make_qs
@@ -24,7 +24,20 @@ class TestUtil(unittest.TestCase):
 
     def test_make_qs_encode(self):
         query_args = {'a': u'тест', 'b': 'тест'}
-        self.assertQueriesEqual(make_qs(query_args), 'a=%D1%82%D0%B5%D1%81%D1%82&b=%D1%82%D0%B5%D1%81%D1%82')
+        qs = make_qs(query_args)
+        self.assertIsInstance(qs, str)
+        self.assertQueriesEqual(qs, 'a=%D1%82%D0%B5%D1%81%D1%82&b=%D1%82%D0%B5%D1%81%D1%82')
+
+    def test_from_ordered_dict(self):
+        qs = make_qs(OrderedDict([('z', 'я'), ('г', 'd'), ('b', ['2', '1'])]))
+        self.assertIsInstance(qs, str)
+        self.assertEqual(qs, 'z=%D1%8F&%D0%B3=d&b=2&b=1')
+
+    def test_unicode_params(self):
+        self.assertQueriesEqual(
+            make_qs({'при': 'вет', u'по': u'ка'}),
+            '%D0%BF%D1%80%D0%B8=%D0%B2%D0%B5%D1%82&%D0%BF%D0%BE=%D0%BA%D0%B0'
+        )
 
     def assertQueriesEqual(self, qs1, qs2):
         qs1_list = sorted(qs1.split('&'))


### PR DESCRIPTION
Это изменение было сделано в копии этой фукции в hhapi.
С переходом на frontik хотелось бы её из hhapi убрать, а в frontik перенести исправление.

Суть исправлений видна в тесте test_unicode_params, который без исправления падает.

https://jira.hh.ru/browse/HH-51161