### PR TITLE
HH-51249 make request to service itself on /status

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Frontik was originally developed by Andrey Tatarinov at [hh.ru](http://hh.ru/) a
 * [Frontik application structure](/docs/frontik-app.md)
 * [Configuring Frontik application](/docs/config-app.md)
 * [Routing — TBA](/docs/routing.md)
+* [Service ulrs](/docs/service-urls.md)
 * [Page generation process](/docs/page-generation.md)
 * [Preprocessors](/docs/preprocessors.md)
 * [Making HTTP requests](/docs/http-client.md)

--- a/docs/config.md
+++ b/docs/config.md
@@ -33,7 +33,7 @@ These options are defined for one Frontik instance (see [options.py](/frontik/op
 | ---------------------------- | ------- | ------------  | --------------------------------------------------------------------- |
 | `app`                        | `str`   | `None`        | Application package name (see [Frontik application structure](/docs/frontik-app.md)) |
 | `app_class`                  | `str`   | `None`        | Application class name defined in application root module, uses default FrontikApplication class if default value is used  |
-| `app_root_url`               | `str`   | `''`          | Root url for the application                                          |
+| `app_root_url`               | `str`   | `''`          | <a name="app_root_url"></a>Root url for the application                                          |
 | `tornado_settings`           | `dict`  | `None`        | tornado.web.Application settings                                      |
 | `autoreload`                 | `bool`  | `True`        | Restart Frontik after changes in application sources or config files  |
 | `debug`                      | `bool`  | `False`       | Enable debug mode                                                     |

--- a/docs/service-urls.md
+++ b/docs/service-urls.md
@@ -1,10 +1,10 @@
 ## Service urls
 
-There are some service urls those available for an any frontik app.
-[`app_root_url` option](config.md#app_root_url) not affects them, they always served from `/`.
+There are some service urls available for an any frontik app.
+[`app_root_url` option](config.md#app_root_url) doesn't affect them, they are always served from `/`.
 
-* `/status?no_network_check=true` - returns `200 OK` if the server is ready to process requests, other errors otherwise.
-  Response contains json with information about the server with a some useful counters:
+* `/status?no_network_check=true` – returns `200 OK` if the server is ready to process requests, an error otherwise.
+  Response contains json with information about the server and some useful counters:
 ```json
 {
     "uptime": "99.28 hours and 16.53 minutes",
@@ -13,7 +13,8 @@ There are some service urls those available for an any frontik app.
     "http requests made": 5811649
 }
 ```
-* `/status` - the same as `/status?no_network_check=true`, but also with additional http request to the server itself.
-* `/version` - xml with app version and versions of some dependencies
-* `/types_count` - returns a list with amount of object types tracked by the garbage collector
-* `/pdb` - opens pdb debbiging session
+* `/status` – the same as `/status?no_network_check=true`, but with additional http request to the server itself for
+  checking client availability.
+* `/version` – xml with app version and versions of some dependencies
+* `/types_count` – returns a list with amount of object types tracked by the garbage collector
+* `/pdb` – opens pdb debugging session

--- a/docs/service-urls.md
+++ b/docs/service-urls.md
@@ -1,0 +1,19 @@
+## Service urls
+
+There are some service urls those available for an any frontik app.
+[`app_root_url` option](config.md#app_root_url) not affects them, they always served from `/`.
+
+* `/status?no_network_check=true` - returns `200 OK` if the server is ready to process requests, other errors otherwise.
+  Response contains json with information about the server with a some useful counters:
+```json
+{
+    "uptime": "99.28 hours and 16.53 minutes",
+    "pages served": 2386542,
+    "bytes from http requests": 25379492996,
+    "http requests made": 5811649
+}
+```
+* `/status` - the same as `/status?no_network_check=true`, but also with additional http request to the server itself.
+* `/version` - xml with app version and versions of some dependencies
+* `/types_count` - returns a list with amount of object types tracked by the garbage collector
+* `/pdb` - opens pdb debbiging session

--- a/frontik/app.py
+++ b/frontik/app.py
@@ -84,6 +84,7 @@ class StatusHandler(tornado.web.RequestHandler):
             )
 
             def _request_ready(result):
+                app_logger.debug('Got reponse for second status request. Code: %d', result.code)
                 if result.error is not None:
                     raise tornado.web.HTTPError(httplib.SERVICE_UNAVAILABLE)
                 self.set_header('Content-Type', 'application/json; charset=UTF-8')

--- a/frontik/app.py
+++ b/frontik/app.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import httplib
 
 import importlib
 import logging
@@ -18,6 +19,7 @@ import frontik.producers.json_producer
 import frontik.producers.xml_producer
 from frontik.handler import ErrorHandler
 import frontik.sentry
+from frontik.util import make_get_request
 
 app_logger = logging.getLogger('frontik.app')
 
@@ -49,26 +51,45 @@ class VersionHandler(tornado.web.RequestHandler):
 
 
 class StatusHandler(tornado.web.RequestHandler):
+
+    @tornado.web.asynchronous
     def get(self):
-        self.set_header('Content-Type', 'application/json; charset=UTF-8')
+        if self.get_argument('no_network_check', 'false') == 'true':
+            self.set_header('Content-Type', 'application/json; charset=UTF-8')
 
-        result = {
-            'pages served': global_stats.page_count,
-            'http requests made': global_stats.http_reqs_count,
-            'bytes from http requests': global_stats.http_reqs_size_sum,
-        }
+            result = {
+                'pages served': global_stats.page_count,
+                'http requests made': global_stats.http_reqs_count,
+                'bytes from http requests': global_stats.http_reqs_size_sum,
+            }
 
-        cur_uptime = time.time() - global_stats.start_time
-        if cur_uptime < 60:
-            uptime_value = '{:.2f} seconds'.format(cur_uptime)
-        elif cur_uptime < 3600:
-            uptime_value = '{:.2f} minutes'.format(cur_uptime / 60)
+            cur_uptime = time.time() - global_stats.start_time
+            if cur_uptime < 60:
+                uptime_value = '{:.2f} seconds'.format(cur_uptime)
+            elif cur_uptime < 3600:
+                uptime_value = '{:.2f} minutes'.format(cur_uptime / 60)
+            else:
+                uptime_value = '{:.2f} hours and {:.2f} minutes'.format(cur_uptime / 3600, (cur_uptime % 3600) / 60)
+
+            result['uptime'] = uptime_value
+            self.finish(result)
         else:
-            uptime_value = '{:.2f} hours and {:.2f} minutes'.format(cur_uptime / 3600, (cur_uptime % 3600) / 60)
+            request = make_get_request(
+                'http://{host}:{port}/status'.format(host='127.0.0.1' if options.host == '0.0.0.0' else options.host,
+                                                     port=options.port),
+                data={'no_network_check': 'true'},
+                connect_timeout=0.5,
+                request_timeout=0.5,
+                follow_redirects=False
+            )
 
-        result['uptime'] = uptime_value
+            def _request_ready(result):
+                if result.error is not None:
+                    raise tornado.web.HTTPError(httplib.SERVICE_UNAVAILABLE)
+                self.set_header('Content-Type', 'application/json; charset=UTF-8')
+                self.finish(result.body)
 
-        self.write(result)
+            self.application.curl_http_client.fetch(request, callback=_request_ready)
 
 
 class PdbHandler(tornado.web.RequestHandler):


### PR DESCRIPTION
/status дергает сам себя, чтобы убедиться, что очередь в curl клиенте ещё может что-то обслуживать. 

Идея перенесена из hhapi.