### PR TITLE
HH-57223 nopost cut-off

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -25,7 +25,3 @@ As well as `debug` parameter, there are also parameters, that can disable templa
 
 * `notpl` — disables templating (XSLT or Jinja2)
 * `noxsl` — old synonym, that works only for XSLT
-
-and template postprocessing:
-
-* `nopost` — disables template postprocessors.

--- a/docs/postprocessing.md
+++ b/docs/postprocessing.md
@@ -32,9 +32,6 @@ __Template postprocessors__ could be used for modifying the response text after 
 One of the possible use-cases is replacing translation placeholders with real localized values.
 Template postprocessor callable receives additional parameter containing the result of templating.
 
-Template postprocessors can be turned off for debug purposes with HTTP argument `nopost`
-(see [Debug mode](/docs/debug.md)).
-
 ```python
 def tpl_postprocessor(handler, template, callback):
     callback(template.replace('foo', 'bar'))

--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -99,14 +99,6 @@ class BaseHandler(tornado.web.RequestHandler):
         self.xml_producer = frontik.producers.xml_producer.XmlProducer(self, self.application.xml)
         self.xml = self.xml_producer  # deprecated synonym
         self.doc = self.xml_producer.doc
-
-        if frontik.util.get_cookie_or_url_param_value(self, 'nopost') is not None:
-            self.require_debug_access()
-            self.apply_postprocessor = False
-            self.log.debug('apply_postprocessor = False due to "nopost" argument')
-        else:
-            self.apply_postprocessor = True
-
         self.finish_group = AsyncGroup(self.check_finished(self._finish_page_cb), name='finish', logger=self.log)
         self._prepared = True
 
@@ -259,11 +251,7 @@ class BaseHandler(tornado.web.RequestHandler):
                     producer = self.xml_producer
 
                 self.log.debug('using %s producer', producer)
-
-                if self.apply_postprocessor:
-                    producer(partial(self._call_postprocessors, self._template_postprocessors, self.finish))
-                else:
-                    producer(self.finish)
+                producer(partial(self._call_postprocessors, self._template_postprocessors, self.finish))
 
             self._call_postprocessors(self._early_postprocessors, _callback)
         else:

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -135,7 +135,7 @@ class DebugTestCase(unittest.TestCase):
         return response
 
     def test_debug_by_basic_auth(self):
-        for param in ('debug', 'nopost', 'noxsl', 'notpl'):
+        for param in ('debug', 'noxsl', 'notpl'):
             response = self.assertDebugResponseCode(page='app/simple_xml?{}'.format(param),
                                                     expected_code=httplib.UNAUTHORIZED)
             self.assertIn('Www-Authenticate', response.headers)
@@ -162,7 +162,7 @@ class DebugTestCase(unittest.TestCase):
             self.assertDebugResponseCode('app/simple_xml?debug', httplib.UNAUTHORIZED, headers={'Authorization': h})
 
     def test_debug_by_header(self):
-        for param in ('debug', 'nopost', 'noxsl', 'notpl'):
+        for param in ('debug', 'noxsl', 'notpl'):
             response = self.assertDebugResponseCode('app/simple_xml?{}'.format(param), httplib.UNAUTHORIZED)
 
             self.assertIn('Www-Authenticate', response.headers)
@@ -187,7 +187,7 @@ class DebugTestCase(unittest.TestCase):
             self.assertEqual('Frontik-Debug-Auth-Header realm="Secure Area"', response.headers['Www-Authenticate'])
 
     def test_debug_by_cookie(self):
-        for param in ('debug', 'noxsl', 'notpl', 'nopost'):
+        for param in ('debug', 'noxsl', 'notpl'):
             self.assertDebugResponseCode(
                 'app/simple_xml', httplib.UNAUTHORIZED, headers={'Cookie': '{}=true'.format(param)}
             )

--- a/tests/test_postprocessors.py
+++ b/tests/test_postprocessors.py
@@ -27,11 +27,6 @@ class TestPostprocessors(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.content, '<html><h1>HEADER</h1>CONTENT</html>')
 
-    def test_template_postprocessors_disabled(self):
-        response = frontik_test_app.get_page(POSTPROCESS_URL.format('nopost'))
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content, '<html><h1>%%header%%</h1>%%content%%</html>')
-
     def test_template_postprocessors_with_json(self):
         response = frontik_test_app.get_page(POSTPROCESS_URL.format('content&notpl'))
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
так как иногда хочется отключать конкретные постпроцессоры, то пусть это делает приложение которое про них знает.
apply_postprocessor пока не вырезал, по-хорошему тоже бы выпилить, но нужно заменить чем-то удобным в xhh тогда (подумать нужно - миксины, simpleHandler-ы и т.п)