### PR TITLE
HH-59025 fix assertXmlEqual: order xml children with deep comparing

### DIFF
--- a/frontik/testing/xml_asserts.py
+++ b/frontik/testing/xml_asserts.py
@@ -34,7 +34,10 @@ def _xml_tags_compare(a, b):
     a_children.sort(_xml_tags_compare)
     b_children.sort(_xml_tags_compare)
     for a_child, b_child in itertools.izip_longest(a_children, b_children):
-        child_res = cmp(a_child, b_child)
+        if etree.iselement(a_child) and etree.iselement(b_child):
+            child_res = _xml_tags_compare(a_child, b_child)
+        else:
+            child_res = cmp(a_child, b_child)
         if child_res != 0:
             res = child_res
             break

--- a/tests/test_xml_asserts.py
+++ b/tests/test_xml_asserts.py
@@ -34,19 +34,19 @@ class TestXmlResponseMixin(unittest.TestCase, xml_asserts.XmlTestCaseMixin):
             self.assertXmlEqual(self.TREE1, self.TREE1)
             self.assertXmlEqual(etree.fromstring(self.TREE1), etree.fromstring(self.TREE1))
         except self.failureException as e:
-            self.fail('XML should be absolute equals (Reported error: "{0!s}")'.format(e))
+            self.fail('XML should be absolute equals (Reported error: "{}")'.format(e))
 
     def test_assertXmlEqual_with_strings(self):
         try:
             self.assertXmlEqual(self.TREE1, self.TREE2)
         except self.failureException as e:
-            self.fail('XML should be almost equals (Reported error: "{0!s}")'.format(e))
+            self.fail('XML should be almost equals (Reported error: "{}")'.format(e))
 
     def test_assertXmlEqual_with_tree(self):
         try:
             self.assertXmlEqual(etree.fromstring(self.TREE1), etree.fromstring(self.TREE2))
         except self.failureException as e:
-            self.fail('XML should be almost equals (Reported error: "{0!s}")'.format(e))
+            self.fail('XML should be almost equals (Reported error: "{}")'.format(e))
 
     def test_assertXmlEqual_same_tags_order(self):
         x1_str = '''
@@ -81,13 +81,13 @@ class TestXmlResponseMixin(unittest.TestCase, xml_asserts.XmlTestCaseMixin):
         try:
             self.assertXmlEqual(x1_str, x2_str)
         except self.failureException as e:
-            self.fail('XML should be almost equals (Reported error: "{0!s}")'.format(e))
+            self.fail('XML should be almost equals (Reported error: "{}")'.format(e))
 
     def test_assertXmlCompatible_abs_equals(self):
         try:
             self.assertXmlCompatible(self.TREE1, self.TREE1)
         except self.failureException as e:
-            self.fail('XML should be absolute equals (Reported error: "{0!s}")'.format(e))
+            self.fail('XML should be absolute equals (Reported error: "{}")'.format(e))
 
     def test_assertXmlCompatible_with_extra_property(self):
         old = '''
@@ -105,7 +105,7 @@ class TestXmlResponseMixin(unittest.TestCase, xml_asserts.XmlTestCaseMixin):
         try:
             self.assertXmlCompatible(old, new)
         except self.failureException as e:
-            self.fail('XML should be compatible (Reported error: "{0!s}")'.format(e))
+            self.fail('XML should be compatible (Reported error: "{}")'.format(e))
 
     def test_assertXmlCompatible_with_extra_tags(self):
         old = '''
@@ -147,7 +147,7 @@ class TestXmlResponseMixin(unittest.TestCase, xml_asserts.XmlTestCaseMixin):
         try:
             self.assertXmlCompatible(old, new)
         except self.failureException as e:
-            self.fail('XML should be compatible (Reported error: "{0!s}")'.format(e))
+            self.fail('XML should be compatible (Reported error: "{}")'.format(e))
 
     def test_assertXmlCompatible_incompatible_property(self):
         old = '''
@@ -193,3 +193,13 @@ class TestXmlResponseMixin(unittest.TestCase, xml_asserts.XmlTestCaseMixin):
             self.assertXmlCompatible(old, new)
         except self.failureException as e:
             self.assertIn('Children length differs', str(e))
+
+    def test_assertXmlEqual_with_similar_children(self):
+        xml_string = ('<a><b><c><d>1</d><e>2</e></c><f><g>3</g></f></b><h>4</h><i><l>5</l><m>6</m></i>'
+                      '<i><l>7</l><m>8</m></i></a>')
+        xml = etree.fromstring(xml_string)
+
+        try:
+            self.assertXmlEqual(xml_string, xml)
+        except self.failureException as e:
+            self.fail('XML should be equals (Reported error: "{}")'.format(e))

--- a/tests/test_xml_asserts.py
+++ b/tests/test_xml_asserts.py
@@ -202,4 +202,4 @@ class TestXmlResponseMixin(unittest.TestCase, xml_asserts.XmlTestCaseMixin):
         try:
             self.assertXmlEqual(xml_string, xml)
         except self.failureException as e:
-            self.fail('XML should be equals (Reported error: "{}")'.format(e))
+            self.fail('XML should be equals after reordering children (Reported error: "{}")'.format(e))

--- a/tests/test_xml_asserts.py
+++ b/tests/test_xml_asserts.py
@@ -198,8 +198,4 @@ class TestXmlResponseMixin(unittest.TestCase, xml_asserts.XmlTestCaseMixin):
         xml_string = ('<a><b><c><d>1</d><e>2</e></c><f><g>3</g></f></b><h>4</h><i><l>5</l><m>6</m></i>'
                       '<i><l>7</l><m>8</m></i></a>')
         xml = etree.fromstring(xml_string)
-
-        try:
-            self.assertXmlEqual(xml_string, xml)
-        except self.failureException as e:
-            self.fail('XML should be equals after reordering children (Reported error: "{}")'.format(e))
+        self.assertXmlEqual(xml_string, xml)


### PR DESCRIPTION
причина была в отсутствии глубокой сортировки xml нод, удивительно, что так долго мы это не замечали.

проверил master всех проектов, зависящих от frontik, тесты проходят.