### PR TITLE
HH-61102 optimize JsonBuilder.to_string()

### DIFF
--- a/frontik/http_client.py
+++ b/frontik/http_client.py
@@ -6,7 +6,7 @@ import re
 import time
 
 from lxml import etree
-import simplejson as json
+import simplejson
 from tornado.concurrent import Future
 from tornado.ioloop import IOLoop
 from tornado.options import options
@@ -279,7 +279,7 @@ _parse_response_xml = partial(_parse_response,
                               response_type='XML')
 
 _parse_response_json = partial(_parse_response,
-                               parser=json.loads,
+                               parser=simplejson.loads,
                                response_type='JSON')
 
 DEFAULT_REQUEST_TYPES = {

--- a/frontik/json_builder.py
+++ b/frontik/json_builder.py
@@ -37,14 +37,8 @@ def _encode_value(v):
         future_logger.info('unresolved Future in JsonBuilder')
         return None
 
-    elif isinstance(v, datetime.date):
-        return v.isoformat()
-
     elif hasattr(v, 'to_dict'):
         return _encode_dict(v.to_dict())
-
-    elif hasattr(v, 'to_json_value'):
-        return _encode_value(v.to_json_value())
 
     return v
 
@@ -112,8 +106,10 @@ class JsonBuilder(object):
 
     def to_string(self):
         if self._encoder is None:
-            # Using FrontikJsonEncoder to generate strings directly is much faster
             return json.dumps(self._concat_chunks(), cls=FrontikJsonEncoder, ensure_ascii=False)
+
+        if isinstance(self._encoder, FrontikJsonEncoder):
+            return json.dumps(self._concat_chunks(), cls=self._encoder, ensure_ascii=False)
 
         # For backwards compatibility, remove when all encoders extend FrontikJsonEncoder
         return json.dumps(self.to_dict(), cls=self._encoder, ensure_ascii=False)

--- a/frontik/json_builder.py
+++ b/frontik/json_builder.py
@@ -1,5 +1,6 @@
 # coding=utf-8
 
+import datetime
 import json
 import logging
 
@@ -9,6 +10,56 @@ from frontik.compat import basestring_type, iteritems
 from frontik.http_client import RequestResult
 
 future_logger = logging.getLogger('frontik.future')
+
+
+def _encode_value(v):
+    def _encode_iterable(l):
+        return [_encode_value(v) for v in l]
+
+    def _encode_dict(d):
+        return {k: _encode_value(v) for k, v in iteritems(d)}
+
+    if isinstance(v, dict):
+        return _encode_dict(v)
+
+    elif isinstance(v, (set, frozenset, list, tuple)):
+        return _encode_iterable(v)
+
+    elif isinstance(v, RequestResult):
+        if v.exception is not None:
+            return JsonBuilder.get_error_node(v.exception)
+        return _encode_value(v.data)
+
+    elif isinstance(v, Future):
+        if v.done():
+            return _encode_value(v.result())
+
+        future_logger.info('unresolved Future in JsonBuilder')
+        return None
+
+    elif isinstance(v, datetime.date):
+        return v.isoformat()
+
+    elif hasattr(v, 'to_dict'):
+        return _encode_dict(v.to_dict())
+
+    elif hasattr(v, 'to_json_value'):
+        return _encode_value(v.to_json_value())
+
+    return v
+
+
+class FrontikJsonEncoder(json.JSONEncoder):
+    """
+    This encoder supports additional value types:
+    * sets and frozensets
+    * datetime.date objects
+    * objects with `to_dict()` method
+    * objects with `to_json_value()` method
+    * `Future` objects (only if the future is resolved)
+    """
+    def default(self, obj):
+        return _encode_value(obj)
 
 
 class JsonBuilder(object):
@@ -24,6 +75,7 @@ class JsonBuilder(object):
         self.root_node = root_node
 
     def put(self, *args, **kwargs):
+        """ Append a chunk of data to JsonBuilder """
         self._data.extend(args)
         if kwargs:
             self._data.append(kwargs)
@@ -40,39 +92,16 @@ class JsonBuilder(object):
             'error': {k: v for k, v in iteritems(exception.attrs)}
         }
 
-    def _check_value(self, v):
-        def _check_iterable(l):
-            return [self._check_value(v) for v in l]
-
-        def _check_dict(d):
-            return {k: self._check_value(v) for k, v in iteritems(d)}
-
-        if isinstance(v, dict):
-            return _check_dict(v)
-
-        elif isinstance(v, (set, frozenset, list, tuple)):
-            return _check_iterable(v)
-
-        elif isinstance(v, RequestResult):
-            if v.exception is not None:
-                return self.get_error_node(v.exception)
-            return self._check_value(v.data)
-
-        elif isinstance(v, Future):
-            if v.done():
-                return self._check_value(v.result())
-
-            self.logger.info('unresolved Future in JsonBuilder')
-            return None
-
-        elif hasattr(v, 'to_dict'):
-            return _check_dict(v.to_dict())
-
-        return v
-
     def to_dict(self):
+        """ Return plain dict from all data appended to JsonBuilder """
+        return _encode_value(self._concat_chunks())
+
+    def _concat_chunks(self):
         result = {}
-        for chunk in self._check_value(self._data):
+        for chunk in self._data:
+            if isinstance(chunk, (RequestResult, Future)) or hasattr(chunk, 'to_dict'):
+                chunk = _encode_value(chunk)
+
             if chunk is not None:
                 result.update(chunk)
 
@@ -82,6 +111,9 @@ class JsonBuilder(object):
         return result
 
     def to_string(self):
-        if self._encoder is not None:
-            return json.dumps(self.to_dict(), cls=self._encoder, ensure_ascii=False)
-        return json.dumps(self.to_dict(), ensure_ascii=False)
+        if self._encoder is None:
+            # Using FrontikJsonEncoder to generate strings directly is much faster
+            return json.dumps(self._concat_chunks(), cls=FrontikJsonEncoder, ensure_ascii=False)
+
+        # For backwards compatibility, remove when all encoders extend FrontikJsonEncoder
+        return json.dumps(self.to_dict(), cls=self._encoder, ensure_ascii=False)

--- a/tests/test_json_builder.py
+++ b/tests/test_json_builder.py
@@ -61,12 +61,6 @@ class TestJsonBuilder(unittest.TestCase):
 
         self.assertSetEqual(set(j.to_dict()['a']['b']), {1, 2, 3})
 
-    def test_date(self):
-        j = JsonBuilder()
-        j.put({'a': {'b': datetime.date(2000, 1, 2)}})
-
-        self.assertEqual(j.to_string(), """{"a": {"b": "2000-01-02"}}""")
-
     def test_encoder(self):
         class CustomValue(object):
             def __iter__(self):
@@ -194,21 +188,4 @@ class TestJsonBuilder(unittest.TestCase):
 
         self.assertEqual(
             j.to_dict(), {'some': ['test1', 'test2', 'test3']}
-        )
-
-    def test_to_json_value(self):
-        class SomeObj(object):
-            def __init__(self, val):
-                self.val = val
-
-            def to_json_value(self):
-                return [self.val]
-
-        j = JsonBuilder()
-        j.put({'1': SomeObj(1)})
-        j.put({'2': SomeObj('2')})
-        j.put({'3': SomeObj(frozenset([3]))})
-
-        self.assertEqual(
-            j.to_dict(), {'1': [1], '2': ['2'], '3': [[3]]}
         )


### PR DESCRIPTION
Использование напрямую энкодера вместо промежуточного шага в виде to_dict даёт двукратный прирост скорости