### PR TITLE
HH-60868 Воркеры

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -33,6 +33,7 @@ These options can be set for each Frontik instance (see [options.py](/frontik/op
 Logging options:
 
 | Option name                  | Type    | Default value | Description                                                            |
+|------------------------------|---------|---------------|------------------------------------------------------------------------|
 | `loglevel`                   | `str`   | `info`        | Python log level                                                       |
 | `logformat`                  | `str`   | see code      | Log entry format for files and syslog                                  |
 | `logfile`                    | `str`   | `None`        | Log file location (set to `None` to disable logging to file)           |

--- a/frontik/app.py
+++ b/frontik/app.py
@@ -205,7 +205,8 @@ class FrontikApplication(tornado.web.Application):
         self.app = settings.get('app')
         self.xml = frontik.producers.xml_producer.ApplicationXMLGlobals(self.config)
         self.json = frontik.producers.json_producer.ApplicationJsonGlobals(self.config)
-        self.curl_http_client = tornado.curl_httpclient.CurlAsyncHTTPClient(max_clients=200)
+        self.curl_http_client = tornado.curl_httpclient.CurlAsyncHTTPClient(
+            max_clients=tornado.options.options.max_http_clients)
         self.dispatcher = RegexpDispatcher(self.application_urls(), self.app)
         self.loggers_initializers = frontik.loggers.bootstrap_app_loggers(self)
 

--- a/frontik/app.py
+++ b/frontik/app.py
@@ -64,7 +64,11 @@ class StatusHandler(tornado.web.RequestHandler):
             uptime_value = '{:.2f} hours and {:.2f} minutes'.format(cur_uptime / 3600, (cur_uptime % 3600) / 60)
 
         result = {
-            'uptime': uptime_value
+            'uptime': uptime_value,
+            'workers': {
+                'total': tornado.options.options.max_http_clients,
+                'free':  len(self.application.curl_http_client._free_list)
+            }
         }
 
         self.finish(result)

--- a/frontik/options.py
+++ b/frontik/options.py
@@ -63,3 +63,5 @@ tornado.options.define('template_cache_limit', default=50, type=int)
 tornado.options.define('debug_labels', default=None, type=dict)
 
 tornado.options.define('sentry_dsn', default=None, type=str, metavar='http://public:secret@example.com/1')
+
+tornado.options.define('max_http_clients', default=200, type=int)

--- a/tests/test_default_urls.py
+++ b/tests/test_default_urls.py
@@ -36,3 +36,7 @@ class TestDefaultUrls(unittest.TestCase):
 
         json_response = json.loads(to_unicode(response.content))
         self.assertIn('uptime', json_response)
+
+        self.assertIn('workers', json_response)
+        self.assertIn('total', json_response['workers'])
+        self.assertIn('free', json_response['workers'])


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-60868

1. Вынесла максимальное количество доступных воркеров в настройки, чтобы можно было менять для каждого приложения в его конфиге
2. Вывела информацию об общем количестве curl-воркеров и количестве свободных воркеров в `/status` для последующего отображения на графике в okmeter
3. Исправила таблицу в доке