### PR TITLE
HH-63448 add future_fold and its two aliases - future_map, future_map_exception

### DIFF
--- a/frontik/async.py
+++ b/frontik/async.py
@@ -4,6 +4,7 @@ import time
 import logging
 
 from tornado.ioloop import IOLoop
+from tornado.concurrent import Future
 
 default_logger = logging.getLogger('frontik.async')
 
@@ -95,3 +96,45 @@ class AsyncGroup(object):
             self.try_finish()
 
         return new_cb
+
+
+def future_fold(future, result_mapper=None, exception_mapper=None):
+    """
+    Creates a new future with result or exception processed by result_mapper and exception_mapper.
+
+    If result_mapper or exception_mapper raises an exception, it will be set as an exception for the resulting future.
+    Any of the mappers can be None — then the result or exception is left as is.
+    """
+
+    res_future = Future()
+
+    def _process(func, value):
+        try:
+            processed = func(value) if func is not None else value
+        except Exception as e:
+            res_future.set_exception(e)
+            return
+        res_future.set_result(processed)
+
+    def _on_ready(wrapped_future):
+        exception = wrapped_future.exception()
+        if exception is not None:
+            if not callable(exception_mapper):
+                def default_exception_func(error):
+                    raise error
+                _process(default_exception_func, exception)
+            else:
+                _process(exception_mapper, exception)
+        else:
+            _process(result_mapper, future.result())
+
+    IOLoop.current().add_future(future, callback=_on_ready)
+    return res_future
+
+
+def future_map(future, func):
+    return future_fold(future, result_mapper=func)
+
+
+def future_map_exception(future, func):
+    return future_fold(future, exception_mapper=func)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,155 @@
+# coding=utf-8
+from tornado.concurrent import Future
+from tornado.testing import AsyncTestCase
+
+from frontik.async import future_fold
+
+
+class MyException(Exception):
+    def __init__(self, result_was=None):
+        self.result_was = result_was
+
+
+class MyOtherException(MyException):
+    pass
+
+
+class FutureProbe(object):
+    _DEFAULT = object
+
+    def __init__(self, future_to_check, stop_cb=None):
+        self._calls = []
+        self._stop_cb = stop_cb
+        future_to_check.add_done_callback(self.build_callback())
+
+    def build_callback(self):
+        def _cb(future):
+            exception = future.exception()
+            result = None
+            if exception is None:
+                result = future.result()
+            self._calls.append((result, exception))
+            if callable(self._stop_cb):
+                self._stop_cb()
+        return _cb
+
+    def assert_single_result_call(self, test, expected_result):
+        test.assertEqual(len(self._calls), 1, msg='should be only one future resolve')
+        test.assertEqual(self._calls[0][0], expected_result, msg='expected future result not matched')
+
+    def assert_single_exception_call(self, test, expected_exception_class, result_was=_DEFAULT):
+        assert issubclass(expected_exception_class, MyException)
+
+        test.assertEqual(len(self._calls), 1, msg='should be only one future resolve with exception')
+        exception = self._calls[0][1]
+        test.assertIsInstance(exception, expected_exception_class,
+                              msg='exception should have expected type')
+        if result_was is not self._DEFAULT:
+            test.assertEqual(exception.result_was, result_was)
+
+
+class TestFutureFold(AsyncTestCase):
+
+    def test_value_to_value(self):
+        marker = object()
+        result_marker = object()
+
+        future = Future()
+        future_probe = FutureProbe(future)
+
+        def _mapper(result):
+            return marker, result
+
+        res_future = future_fold(future, result_mapper=_mapper)
+        check_res_future = FutureProbe(res_future, stop_cb=self.stop)
+
+        future.set_result(result_marker)
+        self.wait()
+
+        future_probe.assert_single_result_call(self, result_marker)
+        check_res_future.assert_single_result_call(self, (marker, result_marker))
+
+    def test_value_to_exception(self):
+        result_marker = object()
+        future = Future()
+        future_probe = FutureProbe(future)
+
+        def _mapper(result):
+            raise MyException(result_was=result)
+
+        res_future = future_fold(future, result_mapper=_mapper)
+        res_future_probe = FutureProbe(res_future, stop_cb=self.stop)
+
+        future.set_result(result_marker)
+        self.wait()
+
+        future_probe.assert_single_result_call(self, result_marker)
+        res_future_probe.assert_single_exception_call(self, MyException, result_marker)
+
+    def test_exception_to_value(self):
+        marker = object()
+
+        future = Future()
+        future_probe = FutureProbe(future)
+
+        def _exception_mapper(exception):
+            # We need to check exception type, but here we can't raise AssertionException.
+            # So it returns None for failing in assertions bellow.
+            if isinstance(exception, MyException):
+                return marker
+            else:
+                return None
+
+        res_future = future_fold(future, exception_mapper=_exception_mapper)
+        res_future_probe = FutureProbe(res_future, stop_cb=self.stop)
+
+        future.set_exception(MyException())
+        self.wait()
+
+        future_probe.assert_single_exception_call(self, MyException)
+        res_future_probe.assert_single_result_call(self, marker)
+
+    def test_exception_to_exception(self):
+        future = Future()
+        future_probe = FutureProbe(future)
+
+        def _exception_mapper(exception):
+            if isinstance(exception, MyException):
+                raise MyOtherException()
+            else:
+                return None
+
+        res_future = future_fold(future, exception_mapper=_exception_mapper)
+        res_future_probe = FutureProbe(res_future, stop_cb=self.stop)
+
+        future.set_exception(MyException())
+        self.wait()
+
+        future_probe.assert_single_exception_call(self, MyException)
+        res_future_probe.assert_single_exception_call(self, MyOtherException)
+
+    def test_both(self):
+        marker = object()
+        second_marker = object()
+        result_marker = object()
+
+        def _mapper(_):
+            return marker
+
+        def _exception_mapper(_):
+            return second_marker
+
+        first_future = Future()
+        folded_future = future_fold(first_future, result_mapper=_mapper, exception_mapper=_exception_mapper)
+        folded_future_probe = FutureProbe(folded_future)
+
+        second_future = Future()
+        second_folded_future = future_fold(second_future, result_mapper=_mapper, exception_mapper=_exception_mapper)
+        second_folded_future_probe = FutureProbe(second_folded_future, stop_cb=self.stop)
+
+        first_future.set_result(result_marker)
+        second_future.set_exception(MyException())
+        self.wait()
+
+        folded_future_probe.assert_single_result_call(self, marker)
+        second_folded_future_probe.assert_single_result_call(self, second_marker)


### PR DESCRIPTION
Функции нужны, чтобы быстро замапить результат или exception в future и сделать новую future (обычно это называется, "свернуть future").
В map'ах можно вернуть значение или бросить exception. Т.е. можно превратить успех-успех, успех-ошибка, ошибка-успех, ошибка-ошибка.

По концепции похоже на [Deferer в twisted](https://twistedmatrix.com/documents/14.0.1/core/howto/defer.html).

примеры использования:
* есть future возвращающая response.data, в котором лежит сырой xml. делаем map функнцию по преобразованию xml в python структуры, получаем новую future (это нужно, например, для быстого написания утилитарных функнций по выдаче чего-нибудь из backend батчом по списку id, типа "загрузи счётчики по этим item ids")
* есть future, которая обычно возвращает json, который как есть кладётся в данные на шаблонизацию (`self.put(get_my_future())`). хочется, чтобы если future завершилась с ошибкой сделать json, который положить в рез-тат. делаем exception_map_func, внутри вместо повторного raise делаем возврат значения в python структурах. на выходе получаем future без exception с рез-тами.