### PR TITLE
HH-67413 use RequestContext in global ContextFilter

### DIFF
--- a/frontik/app.py
+++ b/frontik/app.py
@@ -74,20 +74,7 @@ class StatusHandler(RequestHandler):
 
 
 def app_dispatcher(tornado_app, request, **kwargs):
-    request_id = request.headers.get('X-Request-Id')
-    context_request_id = RequestContext.get('request_id')
-
-    if context_request_id is None or (request_id is not None and request_id != context_request_id):
-        logging.getLogger('frontik.request_handler').warning(
-            'RequestContext is inconsistent: %s != %s', context_request_id, request_id
-        )
-
-        if request_id is None:
-            request_id = FrontikApplication.next_request_id()
-    else:
-        request_id = context_request_id
-
-    request_logger = RequestLogger(request, request_id)
+    request_logger = RequestLogger(request)
     return tornado_app.router(tornado_app, request, request_logger, **kwargs)
 
 

--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -1,14 +1,14 @@
 # coding=utf-8
 
 import base64
-from functools import partial
 import time
+from functools import partial
 
 import tornado.curl_httpclient
 import tornado.httputil
-from tornado.ioloop import IOLoop
 import tornado.options
 import tornado.web
+from tornado.ioloop import IOLoop
 
 import frontik.auth
 import frontik.handler_active_limit
@@ -50,10 +50,10 @@ class BaseHandler(tornado.web.RequestHandler):
     preprocessors = ()
 
     # to restore tornado.web.RequestHandler compatibility
-    def __init__(self, application, request, logger, **kwargs):
+    def __init__(self, application, request, logger=None, **kwargs):
         self._prepared = False
         self.name = self.__class__.__name__
-        self.request_id = logger.request_id
+        self.request_id = RequestContext.get('request_id')
         self.config = application.config
 
         self.log = logger
@@ -64,7 +64,6 @@ class BaseHandler(tornado.web.RequestHandler):
 
         super(BaseHandler, self).__init__(application, request, logger=self.log, **kwargs)
 
-        self.log.register_page_handler(self)
         self._debug_access = None
 
         self._template_postprocessors = []
@@ -95,6 +94,8 @@ class BaseHandler(tornado.web.RequestHandler):
         self.doc = self.xml_producer.doc
 
         self._prepared = True
+
+        super(BaseHandler, self).prepare()
 
     def require_debug_access(self, login=None, passwd=None):
         if self._debug_access is None:

--- a/frontik/routing.py
+++ b/frontik/routing.py
@@ -43,13 +43,13 @@ class FileMappingRouter(object):
             return self.handle_404(application, request, logger, **kwargs)
         except:
             logger.exception('error while importing %s module', page_module_name)
-            return ErrorHandler(application, request, logger, status_code=500, **kwargs)
+            return ErrorHandler(application, request, logger=logger, status_code=500, **kwargs)
 
         if not hasattr(page_module, 'Page'):
             logger.error('%s.Page class not found', page_module_name)
             return self.handle_404(application, request, logger, **kwargs)
 
-        return page_module.Page(application, request, logger, **kwargs)
+        return page_module.Page(application, request, logger=logger, **kwargs)
 
     def __repr__(self):
         return '{}.{}(<{}>)'.format(__package__, self.__class__.__name__, self.name)
@@ -63,7 +63,7 @@ class FileMappingRouter(object):
             handler_class, kwargs = handler_class_and_kwargs
             return handler_class(application, request, logger=logger, **kwargs)
 
-        return ErrorHandler(application, request, logger, status_code=404, **kwargs)
+        return ErrorHandler(application, request, logger=logger, status_code=404, **kwargs)
 
 
 class FrontikRouter(object):
@@ -94,13 +94,13 @@ class FrontikRouter(object):
                 logger.debug('using %r', handler)
                 extend_request_arguments(request, match)
                 try:
-                    return handler(application, request, logger, **kwargs)
+                    return handler(application, request, logger=logger, **kwargs)
                 except Exception as e:
                     logger.exception('error handling request: %s in %r', e, handler)
-                    return ErrorHandler(application, request, logger, status_code=500, **kwargs)
+                    return ErrorHandler(application, request, logger=logger, status_code=500, **kwargs)
 
         logger.error('match for request url "%s" not found', request.uri)
-        return ErrorHandler(application, request, logger, status_code=404, **kwargs)
+        return ErrorHandler(application, request, logger=logger, status_code=404, **kwargs)
 
     def reverse_url(self, name, *args, **kwargs):
         if name not in self.handler_names:


### PR DESCRIPTION
Переношу ContextFilter, добавляющий request_id и handler_name в лог-записи из реквест-логера в рутовый логер. Теперь эта инфа будет во всех записях (если доступна).

Это позволяет избавиться от патча торнады с прокидыванием нашего логера в RequestHandler. Для этого делаю сначала logger опциональным в ините