### PR TITLE
HH-68956 disable breadcrumbs in sentry client

### DIFF
--- a/frontik/loggers/sentry.py
+++ b/frontik/loggers/sentry.py
@@ -26,7 +26,11 @@ def bootstrap_logger(app):
             handler.get_sentry_logger = lambda: None
             return
 
-        sentry_client = AsyncSentryClient(dsn=dsn, http_client=app.curl_http_client)
+        sentry_client = AsyncSentryClient(
+            dsn=dsn, http_client=app.curl_http_client,
+            # breadcrumbs have serious performance penalties
+            enable_breadcrumbs=False, install_logging_hook=False
+        )
 
         def get_sentry_logger():
             if not hasattr(handler, 'sentry_logger'):


### PR DESCRIPTION
сбор "крошек" добавили в свежих клиентах - https://docs.sentry.io/clients/python/breadcrumbs/

они инструментируют logger и собирают с него записи до падения (вне стека ошибки)
фича крутая, но тормозит :)

проверил старый клиент 5.33.0, неизвестные доп. опции он не заметит, не упадёт.

перед выпуском буду тестировать с hhapi/xhh на новой 6.0.0 и старой версии клиента.