### PR TITLE
HH-66959 fix debug output if some data not exist

### DIFF
--- a/frontik/handler_debug.py
+++ b/frontik/handler_debug.py
@@ -137,18 +137,20 @@ def response_from_debug(request, response):
         response_info = frontik.xml_util.xml_to_dict(original_response)
         original_response.getparent().remove(original_response)
 
-        original_buffer = base64.b64decode(response_info['buffer'])
+        original_buffer = base64.b64decode(response_info.get('buffer', ''))
 
         headers = dict(response.headers)
-        if response_info['headers']:
-            headers.update(response_info['headers'])
+        response_info_headers = response_info.get('headers', {})
+        if response_info_headers:
+            headers.update(response_info_headers)
 
         fake_response = HTTPResponse(
             request,
-            int(response_info['code']),
+            int(response_info.get('code', 599)),
             headers=HTTPHeaders(headers),
             buffer=BytesIO(original_buffer),
-            effective_url=response.effective_url, request_time=response.request_time,
+            effective_url=response.effective_url,
+            request_time=response.request_time,
             time_info=response.time_info
         )
 


### PR DESCRIPTION
редкий баг. проявлялся когда один из java'овых проектов возвращал debug респонс без ноды buffer (из-за особенностей настройки json сериализации, наверное).

чтобы там не было, наверное лучше не падать в таком случае и в других случаях, когда данных не хватает.