### PR TITLE
refactor finish_with_postprocessors

### DIFF
--- a/frontik/async.py
+++ b/frontik/async.py
@@ -35,9 +35,6 @@ class AsyncGroup(object):
     def _message(self, message):
         return self._log_name + ': ' + message
 
-    def is_finished(self):
-        return self._finished
-
     def abort(self):
         async_logger.info(self._message('aborting async group'))
         self._aborted = True

--- a/tests/projects/test_app/pages/preprocessors_new.py
+++ b/tests/projects/test_app/pages/preprocessors_new.py
@@ -36,15 +36,20 @@ def pp1(handler):
 
 @preprocessor
 def pp2(handler):
+    def _cb(_, __):
+        handler.json.put({'put_request_finished': True})
+
     self_uri = 'http://' + handler.request.host + handler.request.path
-    future = handler.post_url(self_uri)
+    future = handler.put_url(self_uri, callback=_cb)
     handler.run.append('pp2')
     handler.pp2_future = future
 
     if handler.get_argument('raise_error', 'false') != 'false':
         raise HTTPError(400)
-    elif handler.get_argument('finish_with_postprocessors', 'false') != 'false':
-        handler.finish_with_postprocessors()
+    elif handler.get_argument('abort_and_run_postprocessors', 'false') != 'false':
+        handler.abort_pending_and_run_postprocessors()
+    elif handler.get_argument('wait_and_run_postprocessors', 'false') != 'false':
+        handler.wait_pending_and_run_postprocessors()
     elif handler.get_argument('redirect', 'false') != 'false':
         handler.redirect(self_uri + '?redirected=true')
     elif handler.get_argument('finish', 'false') != 'false':
@@ -83,8 +88,8 @@ class Page(PageHandler):
 
         self.run.append('get_page')
 
-    def post_page(self):
-        self.text = {'post': self.run}
+    def put_page(self):
+        self.text = {'put_request_preprocessors': self.run}
 
     @staticmethod
     def postprocessor(handler, callback):

--- a/tests/projects/test_app/pages/run_postprocessors.py
+++ b/tests/projects/test_app/pages/run_postprocessors.py
@@ -16,7 +16,7 @@ class Page(PageHandler):
         self.add_early_postprocessor(pp)
 
     def get_page(self):
-        content_type = self.get_argument('type', None)
+        content_type = self.get_argument('type')
 
         def fail_page(_, __):
             raise HTTPError(500)
@@ -33,7 +33,7 @@ class Page(PageHandler):
             self.doc.put(etree.Element('ok'))
             self.set_xsl('simple.xsl')
 
-        self.finish_with_postprocessors()
+        self.abort_pending_and_run_postprocessors()
 
     def post_page(self):
         pass

--- a/tests/projects/test_app/pages/write_error.py
+++ b/tests/projects/test_app/pages/write_error.py
@@ -13,4 +13,4 @@ class Page(frontik.handler.PageHandler):
         if self.get_argument('fail_write_error', 'false') == 'true':
             raise Exception('exception in write_error')
 
-        self.finish_with_postprocessors()
+        self.abort_pending_and_run_postprocessors()

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -27,17 +27,29 @@ class TestPreprocessors(unittest.TestCase):
                 'run': [
                     'pp01', 'pp02', 'pp1-before', 'pp1-between', 'pp1-after', 'pp2', 'pp3', 'get_page'
                 ],
-                'post': ['pp01', 'pp02'],
+                'put_request_finished': True,
+                'put_request_preprocessors': ['pp01', 'pp02'],
                 'postprocessor': True
             }
         )
 
-    def test_preprocessors_new_finish_with_postprocessors(self):
-        response_json = frontik_test_app.get_page_json('preprocessors_new?finish_with_postprocessors=true')
+    def test_preprocessors_new_abort_and_run_postprocessors(self):
+        response_json = frontik_test_app.get_page_json('preprocessors_new?abort_and_run_postprocessors=true')
         self.assertEqual(
             response_json,
             {
                 'run': ['pp01', 'pp02', 'pp1-before', 'pp1-between', 'pp1-after', 'pp2'],
+                'postprocessor': True
+            }
+        )
+
+    def test_preprocessors_new_wait_and_run_postprocessors(self):
+        response_json = frontik_test_app.get_page_json('preprocessors_new?wait_and_run_postprocessors=true')
+        self.assertEqual(
+            response_json,
+            {
+                'run': ['pp01', 'pp02', 'pp1-before', 'pp1-between', 'pp1-after', 'pp2'],
+                'put_request_finished': True,
                 'postprocessor': True
             }
         )

--- a/tests/test_run_postprocessors.py
+++ b/tests/test_run_postprocessors.py
@@ -7,7 +7,7 @@ from .instances import frontik_test_app
 
 
 class TestFinishWithPostprocessors(unittest.TestCase):
-    def test_finish_with_postprocessors(self):
+    def test_run_postprocessors(self):
         type_to_content = {
             'text': b'ok',
             'xml': b"<?xml version='1.0' encoding='utf-8'?>\n<doc><ok/></doc>",
@@ -16,7 +16,7 @@ class TestFinishWithPostprocessors(unittest.TestCase):
         }
 
         for content_type, content in iteritems(type_to_content):
-            response = frontik_test_app.get_page('finish_with_postprocessors?type={}'.format(content_type))
+            response = frontik_test_app.get_page('run_postprocessors?type={}'.format(content_type))
             self.assertEqual(response.status_code, 200)
             self.assertEqual(response.content, content)
             self.assertEqual(response.headers['X-Foo'], 'Bar')


### PR DESCRIPTION
для препроцессоров:

этот код прерывает цепочку препроцессоров и не ждёт завершения уже начатых запросов, переходя к постпроцессорам сразу
```python
def pp(handler, cb)
   # что-то
   handler.finish_with_postprocessors()
   # нет вызова cb()
```

если пропустить handler.finish_with_postprocessors(), то цепочка тоже прервётся, но уже начатые запросы не прервутся, и только когда они все завершатся — запустятся постпроцессоры

оба поведения имеют право на жизнь и используются

первое переписываем так:
```python
def pp(handler):
    # что-то
    handler.abort_pending_and_run_postprocessors()
```

второе так:
```python
def pp(handler):
    # что-то
    handler.wait_pending_and_run_postprocessors()
```

abort_pending_and_run_postprocessors можно использовать в принципе везде, где надо срочно завершить страницу и запустить шаблонизатор (и в препроцессорах и в методе _page)

wait_pending_and_run_postprocessors имеет смысл использовать только в препроцессорах, т.к. основная идея — дождаться уже сделанных запросов, а новые не начинать (в методе _page для этого достаточно ничего не делать)