### PR TITLE
HH-73932 Raise custom HTTPError for debug mode

### DIFF
--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -46,6 +46,10 @@ class HTTPError(tornado.web.HTTPError):
         self.headers = headers
 
 
+class DebugUnauthorizedHTTPError(HTTPError):
+    pass
+
+
 class BaseHandler(tornado.web.RequestHandler):
 
     preprocessors = ()
@@ -103,7 +107,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 debug_access = (error is None)
                 if not debug_access:
                     code, headers = error
-                    raise HTTPError(code, headers=headers)
+                    raise DebugUnauthorizedHTTPError(code, headers=headers)
 
             self._debug_access = debug_access
 

--- a/tests/projects/no_debug_app/pages/write_error.py
+++ b/tests/projects/no_debug_app/pages/write_error.py
@@ -1,0 +1,13 @@
+# coding=utf-8
+
+import frontik.handler
+
+
+class Page(frontik.handler.PageHandler):
+    def get_page(self):
+        pass
+
+    def write_error(self, status_code=500, **kwargs):
+        exception = kwargs['exc_info'][1] if 'exc_info' in kwargs else None
+        if isinstance(exception, frontik.handler.DebugUnauthorizedHTTPError):
+            self.finish('DebugUnauthorizedHTTPError')

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -117,6 +117,10 @@ class DebugTestCase(unittest.TestCase):
         for h in invalid_headers:
             self.assertDebugResponseCode('simple?debug', http_codes.UNAUTHORIZED, headers={'Authorization': h})
 
+    def test_custom_exception_in_write_error(self):
+        response = frontik_no_debug_app.get_page('write_error?debug', headers={'Authorization': 'wrong'})
+        self.assertEqual(to_unicode(response.content), 'DebugUnauthorizedHTTPError')
+
     def test_debug_by_header(self):
         for param in ('debug', 'noxsl', 'notpl'):
             response = self.assertDebugResponseCode('simple?{}'.format(param), http_codes.UNAUTHORIZED)


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-73932

Сейчас [кидается HTTPError](https://github.com/hhru/frontik/blob/bdf2ac3c7fc17ddd93472da62ca6db90fd50c2e0/frontik/handler.py#L108-L108), а косвенным признаком непрошедшей дебаг-авторизации является [`status_code == 401`](https://github.com/hhru/hh.sites.main/blob/5bd1ee871963e89564965e903d3d9a31bc99c461/xhh/page.py#L200-L200), что не очень правильно и не даёт при необходимости нарисовать настоящую 401.