### PR TITLE
HH-84072 pass app version to sentry

### DIFF
--- a/frontik/app.py
+++ b/frontik/app.py
@@ -126,6 +126,9 @@ class FrontikApplication(Application):
         version.text = 'unknown'
         return [version]
 
+    def application_version(self):
+        return None
+
     def init_async(self):
         init_future = Future()
         init_future.set_result(None)

--- a/frontik/loggers/sentry.py
+++ b/frontik/loggers/sentry.py
@@ -28,6 +28,7 @@ def bootstrap_logger(app):
 
     sentry_client = AsyncSentryClient(
         dsn=dsn, http_client=app.http_client_factory.tornado_http_client,
+        release=app.application_version(),
         # breadcrumbs have serious performance penalties
         enable_breadcrumbs=False, install_logging_hook=False, install_sys_hook=False
     )


### PR DESCRIPTION
В sentry сейчас нет никакой привязки к релизам, хотя эта информация у нас всегда есть в приложении

Проставляться будет вот так: hhru/hh.sites.main#8435