### PR TITLE
HH-87466 Finish on 405

### DIFF
--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -215,7 +215,8 @@ class PageHandler(RequestHandler):
             name for name in ('get', 'post', 'put', 'delete') if '{}_page'.format(name) in vars(self.__class__)
         ]
         self.set_header('Allow', ', '.join(allowed_methods))
-        raise HTTPErrorWithPostprocessors(405)
+        self.set_status(405)
+        self.finish()
 
     def get_page_fail_fast(self, request_result: RequestResult):
         self.__return_error(request_result.response.code)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -78,4 +78,4 @@ class TestHttpError(unittest.TestCase):
         response = frontik_test_app.get_page('write_error', method=requests.put)
         self.assertEqual(response.status_code, 405)
         self.assertEqual(response.headers['allow'], 'get')
-        self.assertEqual(response.content, b'{"write_error": true}')
+        self.assertEqual(response.content, b'')


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-87466

При 405 Фронтик кидает `HTTPErrorWithPostprocessors`, и приложение выдаёт XML, сформированный постпроцессорами.