### PR TITLE
HH-96052 Add pydevd handler

### DIFF
--- a/docs/pydevd.md
+++ b/docs/pydevd.md
@@ -1,0 +1,10 @@
+## Pydevd debug handler
+
+Frontik provides special URL `/pydevd` to invoke `pydevd.settrace()` function. It's only allowed with `debug` option
+ set to True in app config.
+
+To debug app, you should start a debug server on your host and then open `/pydevd` URL: Frontik will try to connect
+ to debug server on host that made a request at port `32223`, unless other is specified.
+
+It's not always possible to determine host IP, so, you can provide ip and port of debug server explicitly:
+`/pydevd?ip=10.208.80.148&port=10050`.


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-96052

Сейчас, чтобы запустить сервис на frontik в режиме отладки, необходимо сделать следующее:

1. поставить в контейнер pydevd
2. узнать IP своей машины
3. открыть в IDEA окошко дебаггера и обновить там IP
4. скопировать в app/_init_.py строки с pydevd.settrace(...) из окошка дебаггера
5. перезапустить сервис в контейнере

Есть идея как немного сократить этот путь: во frontik надо создать хэндлер, который будет сам брать IP клиента и вызывать pydevd.settrace с необходимыми параметрами, это избавит нас от шагов 2-4.