### PR TITLE
HH-96502 Do not process failed requests when its are not waited

### DIFF
--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -48,6 +48,17 @@ class HTTPErrorWithPostprocessors(tornado.web.HTTPError):
 handler_logger = logging.getLogger('handler')
 
 
+def _fail_fast_policy(fail_fast, waited, host, uri):
+    if fail_fast and not waited:
+        handler_logger.warning(
+            'attempted to make NOT waited http request to %s %s with fail fast policy, turn off fail_fast',
+            host, uri
+        )
+        return False
+
+    return fail_fast
+
+
 class PageHandler(RequestHandler):
 
     preprocessors = ()
@@ -537,6 +548,8 @@ class PageHandler(RequestHandler):
                 connect_timeout=None, request_timeout=None, max_timeout_tries=None,
                 callback=None, waited=True, parse_response=True, parse_on_error=True, fail_fast=False):
 
+        fail_fast = _fail_fast_policy(fail_fast, waited, host, uri)
+
         client_method = lambda callback: self._http_client.get_url(
             host, uri, name=name, data=data, headers=headers, follow_redirects=follow_redirects,
             connect_timeout=connect_timeout, request_timeout=request_timeout, max_timeout_tries=max_timeout_tries,
@@ -548,6 +561,8 @@ class PageHandler(RequestHandler):
     def head_url(self, host, uri, *, name=None, data=None, headers=None, follow_redirects=True,
                  connect_timeout=None, request_timeout=None, max_timeout_tries=None,
                  callback=None, waited=True, fail_fast=False):
+
+        fail_fast = _fail_fast_policy(fail_fast, waited, host, uri)
 
         client_method = lambda callback: self._http_client.head_url(
             host, uri, data=data, name=name, headers=headers, follow_redirects=follow_redirects,
@@ -562,6 +577,8 @@ class PageHandler(RequestHandler):
                  connect_timeout=None, request_timeout=None, max_timeout_tries=None, idempotent=False,
                  callback=None, waited=True, parse_response=True, parse_on_error=True, fail_fast=False):
 
+        fail_fast = _fail_fast_policy(fail_fast, waited, host, uri)
+
         client_method = lambda callback: self._http_client.post_url(
             host, uri, data=data, name=name, headers=headers, files=files, content_type=content_type,
             follow_redirects=follow_redirects, connect_timeout=connect_timeout, request_timeout=request_timeout,
@@ -575,6 +592,8 @@ class PageHandler(RequestHandler):
                 connect_timeout=None, request_timeout=None, max_timeout_tries=None,
                 callback=None, waited=True, parse_response=True, parse_on_error=True, fail_fast=False):
 
+        fail_fast = _fail_fast_policy(fail_fast, waited, host, uri)
+
         client_method = lambda callback: self._http_client.put_url(
             host, uri, name=name, data=data, headers=headers, content_type=content_type,
             connect_timeout=connect_timeout, request_timeout=request_timeout, max_timeout_tries=max_timeout_tries,
@@ -586,6 +605,8 @@ class PageHandler(RequestHandler):
     def delete_url(self, host, uri, *, name=None, data=None, headers=None, content_type=None,
                    connect_timeout=None, request_timeout=None, max_timeout_tries=None,
                    callback=None, waited=True, parse_response=True, parse_on_error=True, fail_fast=False):
+
+        fail_fast = _fail_fast_policy(fail_fast, waited, host, uri)
 
         client_method = lambda callback: self._http_client.delete_url(
             host, uri, name=name, data=data, headers=headers, content_type=content_type,

--- a/tests/projects/test_app/pages/async_group/not_waited_failed_requests.py
+++ b/tests/projects/test_app/pages/async_group/not_waited_failed_requests.py
@@ -1,0 +1,41 @@
+from tornado import gen
+
+from frontik.handler import PageHandler
+
+
+class Page(PageHandler):
+    data = {}
+
+    def get_page(self):
+        if self.request.method == 'HEAD':
+            self.head_page()
+            return
+
+        if not self.data:
+            # HTTP request with waited=False and fail_fast=True should not influence responses to client
+            yield self.head_url(self.request.host, self.request.path, waited=False, fail_fast=True)
+            yield self.post_url(self.request.host, self.request.path, waited=False, fail_fast=True)
+            yield self.put_url(self.request.host, self.request.path, waited=False, fail_fast=True)
+            yield self.delete_url(self.request.host, self.request.path, waited=False, fail_fast=True)
+
+            self.json.put({'get': True})
+        else:
+            self.json.put(self.data)
+            self.data = {}
+
+    @gen.coroutine
+    def head_page(self):
+        self._record_failed_request({'head_failed': True})
+
+    def post_page(self):
+        self._record_failed_request({'post_failed': True})
+
+    def put_page(self):
+        self._record_failed_request({'put_failed': True})
+
+    def delete_page(self):
+        self._record_failed_request({'delete_failed': True})
+
+    def _record_failed_request(self, data):
+        Page.data.update(data)
+        raise ValueError('Some error')

--- a/tests/test_asyncgroup_handler.py
+++ b/tests/test_asyncgroup_handler.py
@@ -48,3 +48,10 @@ class TestAsyncGroup(unittest.TestCase):
 
         json = frontik_test_app.get_page_json('async_group/not_waited_requests')
         self.assertEqual(json, {'post_made': True, 'put_made': True, 'delete_cancelled': True})
+
+    def test_not_waited_failed_requests(self):
+        json = frontik_test_app.get_page_json('async_group/not_waited_failed_requests')
+        self.assertEqual({'get': True}, json)
+
+        json = frontik_test_app.get_page_json('async_group/not_waited_failed_requests')
+        self.assertEqual({'head_failed': True, 'post_failed': True, 'put_failed': True, 'delete_failed': True}, json)


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-96502

На данный момент возможна ситуация:
* посылаем куда-нибудь HTTP запрос в пределах handler
* пометили запрос как неожидаемый (`waited=False`) и выставлен флаг для обработки fail-а (`fail_fast=True`)
* запрос зафейлился

В этом случаи без разницы, что мы отвечаем клиенту, логика прыгнет в ветку `fail_fast`.


Если исходить из логики, что мы уже пометили запрос как неожидаемый, то он не должен влиять на ответ клиенту.

Соответственно вычисляю флаг `fail_fast`, как `fail_fast = fail_fast and waited`. 