### PR TITLE
Add json_request field to PageHandler

### DIFF
--- a/tests/projects/test_app/pages/handler/json.py
+++ b/tests/projects/test_app/pages/handler/json.py
@@ -1,0 +1,15 @@
+from tornado.web import HTTPError
+import frontik.handler
+
+
+class Page(frontik.handler.PageHandler):
+    def _page_handler(self):
+        if self.json_request is None:
+            raise HTTPError(400)
+        self.text = self.json_request.get('foo', 'baz')
+
+    def post_page(self):
+        return self._page_handler()
+
+    def put_page(self):
+        return self._page_handler()

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -39,3 +39,11 @@ class TestHandler(unittest.TestCase):
     def test_204(self):
         response = frontik_test_app.get_page('finish_204')
         self.assertEqual(response.status_code, 204)
+
+    def test_json(self):
+        for method in (requests.post, requests.put):
+            response = frontik_test_app.get_page('handler/json', method=method, json={'foo': 'bar'})
+            self.assertEqual(response.content, b'bar')
+
+            response = frontik_test_app.get_page('handler/json', method=method, data=b'')
+            self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
При POST-запросе с `Content-Type: application/json` добавляется поле `json_request` со словарём с полями data и error — данными распаршенными из тела запроса и ошибкой парсинга соответственно.