### PR TITLE
HH-97952 Add json_body field and get_json_argument method to PageHandler

### DIFF
--- a/tests/projects/test_app/pages/handler/json.py
+++ b/tests/projects/test_app/pages/handler/json.py
@@ -1,0 +1,12 @@
+import frontik.handler
+
+
+class Page(frontik.handler.PageHandler):
+    def _page_handler(self):
+        self.text = self.get_body_argument('foo')
+
+    def post_page(self):
+        return self._page_handler()
+
+    def put_page(self):
+        return self._page_handler()

--- a/tests/projects/test_app/pages/handler/json_optional_args.py
+++ b/tests/projects/test_app/pages/handler/json_optional_args.py
@@ -1,0 +1,12 @@
+import frontik.handler
+
+
+class Page(frontik.handler.PageHandler):
+    def _page_handler(self):
+        self.text = self.get_body_argument('foo', 'baz')
+
+    def post_page(self):
+        return self._page_handler()
+
+    def put_page(self):
+        return self._page_handler()


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-97952

`PageHandler.get_body_argument`, теперь возвращает поля JSON, переданного в теле POST/PUT-запроса.

Также добавлено поле `PageHandler.json_body`, в котором лежит распарсенный из тела запроса json. Если его не получилось распарсить, кидается `JSONBodyParseError()`, отнаследованный от `HTTPError(400)`.
