### PR TITLE
HH-122286 added direct preprocessor run order & methods

### DIFF
--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -27,7 +27,7 @@ from frontik.futures import AbortAsyncGroup, AsyncGroup
 from frontik.debug import DEBUG_HEADER_NAME, DebugMode
 from frontik.timeout_tracking import get_timeout_checker
 from frontik.loggers.stages import StagesLogger
-from frontik.preprocessors import _get_preprocessors, _unwrap_preprocessors
+from frontik.preprocessors import _get_preprocessors, _unwrap_preprocessors, _get_preprocessor_name
 from frontik.util import make_url
 from frontik.version import version as frontik_version
 
@@ -74,6 +74,7 @@ def _fail_fast_policy(fail_fast, waited, host, uri):
 class PageHandler(RequestHandler):
 
     preprocessors = ()
+    priority_preprocessors_order = []
 
     def __init__(self, application, request, **kwargs):
         self.name = self.__class__.__name__
@@ -84,6 +85,7 @@ class PageHandler(RequestHandler):
 
         super().__init__(application, request, **kwargs)
 
+        self._launched_preprocessors = []
         self._preprocessor_futures = []
         self._exception_hooks = []
 
@@ -251,9 +253,25 @@ class PageHandler(RequestHandler):
     @gen.coroutine
     def _execute_page(self, page_handler_method):
         self.stages_logger.commit_stage('prepare')
+        preprocessors = _get_preprocessors(page_handler_method.__func__)
+        priority_names = list(map(
+            lambda p: p.preprocessor_name,
+            self.priority_preprocessors_order)
+        )
+        priority_preprocessors = []
+        rest_preprocessors = []
+        for preprocessor in preprocessors:
+            if _get_preprocessor_name(preprocessor) in priority_names:
+                priority_preprocessors.append(preprocessor)
+            else:
+                rest_preprocessors.append(preprocessor)
 
-        preprocessors = _unwrap_preprocessors(self.preprocessors) + _get_preprocessors(page_handler_method.__func__)
-        preprocessors_completed = yield self._run_preprocessors(preprocessors)
+        def _sort_priority(preprocessor):
+            return priority_names.index(_get_preprocessor_name(preprocessor))
+
+        priority_preprocessors.sort(key=_sort_priority)
+        preprocessors_to_run = _unwrap_preprocessors(self.preprocessors) + priority_preprocessors + rest_preprocessors
+        preprocessors_completed = yield self._run_preprocessors(preprocessors_to_run)
 
         if not preprocessors_completed:
             self.log.info('page was already finished, skipping page method')
@@ -518,14 +536,30 @@ class PageHandler(RequestHandler):
             del self._mandatory_cookies[name]
         super().clear_cookie(name, path, domain)
 
+    def is_preprocessor_launched(self, preprocessor):
+        return preprocessor.preprocessor_name in self._launched_preprocessors
+
     @gen.coroutine
-    def _run_preprocessors(self, preprocessors):
-        for p in preprocessors:
-            yield gen.coroutine(p)(self)
+    def _run_preprocessor_function(self, preprocessor_function):
+        yield gen.coroutine(preprocessor_function)(self)
+        self._launched_preprocessors.append(
+            _get_preprocessor_name(preprocessor_function)
+        )
+
+    @gen.coroutine
+    def run_preprocessor(self, preprocessor):
+        if self._finished:
+            self.log.info('page was already finished, cannot init preprocessor')
+            return False
+        yield self._run_preprocessor_function(preprocessor.function)
+
+    @gen.coroutine
+    def _run_preprocessors(self, preprocessor_functions):
+        for p in preprocessor_functions:
+            yield self._run_preprocessor_function(p)
             if self._finished:
                 self.log.info('page was already finished, breaking preprocessors chain')
                 return False
-
         yield gen.multi(self._preprocessor_futures)
 
         self._preprocessor_futures = None

--- a/frontik/preprocessors.py
+++ b/frontik/preprocessors.py
@@ -2,7 +2,7 @@ def _get_preprocessor_name(preprocessor_function):
     return f'{preprocessor_function.__module__}.{preprocessor_function.__name__}'
 
 
-def preprocessor(function_or_list, order=None):
+def preprocessor(function_or_list):
     """Creates a preprocessor decorator for `PageHandler.get_page`, `PageHandler.post_page` etc.
 
     Preprocessor is a function that accepts handler instance as its only parameter.
@@ -37,7 +37,7 @@ def preprocessor(function_or_list, order=None):
 
     def preprocessor_decorator(func):
         if callable(function_or_list):
-            _register_preprocessors(func, [function_or_list], order=order)
+            _register_preprocessors(func, [function_or_list])
         else:
             for dep in reversed(function_or_list):
                 dep(func)

--- a/frontik/preprocessors.py
+++ b/frontik/preprocessors.py
@@ -65,3 +65,7 @@ def _unwrap_preprocessors(preprocessors):
 
 def _register_preprocessors(func, preprocessors):
     setattr(func, '_preprocessors', preprocessors + _get_preprocessors(func))
+
+
+def make_preprocessors_names_list(preprocessors_list):
+    return list(map(lambda p: p.preprocessor_name, preprocessors_list))

--- a/frontik/preprocessors.py
+++ b/frontik/preprocessors.py
@@ -1,4 +1,8 @@
-def preprocessor(function_or_list):
+def _get_preprocessor_name(preprocessor_function):
+    return f'{preprocessor_function.__module__}.{preprocessor_function.__name__}'
+
+
+def preprocessor(function_or_list, order=None):
     """Creates a preprocessor decorator for `PageHandler.get_page`, `PageHandler.post_page` etc.
 
     Preprocessor is a function that accepts handler instance as its only parameter.
@@ -33,7 +37,7 @@ def preprocessor(function_or_list):
 
     def preprocessor_decorator(func):
         if callable(function_or_list):
-            _register_preprocessors(func, [function_or_list])
+            _register_preprocessors(func, [function_or_list], order=order)
         else:
             for dep in reversed(function_or_list):
                 dep(func)
@@ -42,9 +46,10 @@ def preprocessor(function_or_list):
 
     if callable(function_or_list):
         dep_name = function_or_list.__name__
+        preprocessor_decorator.preprocessor_name = _get_preprocessor_name(function_or_list)
+        preprocessor_decorator.function = function_or_list
     else:
         dep_name = [f.__name__ for f in function_or_list]
-
     preprocessor_decorator.func_name = f'preprocessor_decorator({dep_name})'
 
     return preprocessor_decorator

--- a/tests/projects/test_app/pages/preprocessors/priority_preprocessors.py
+++ b/tests/projects/test_app/pages/preprocessors/priority_preprocessors.py
@@ -1,0 +1,37 @@
+from frontik.handler import PageHandler
+from frontik.preprocessors import preprocessor, make_preprocessors_names_list
+
+
+@preprocessor
+def pp0(handler):
+    handler.called_preprocessors = ['pp0']
+
+
+@preprocessor
+def pp1(handler):
+    handler.called_preprocessors.append('pp1')
+
+
+@preprocessor
+def pp2(handler):
+    handler.called_preprocessors.append('pp2')
+
+
+@preprocessor
+def pp3(handler):
+    handler.called_preprocessors.append('pp3')
+
+
+class Page(PageHandler):
+    preprocessors = [pp0]
+    _priority_preprocessor_names = make_preprocessors_names_list([
+        pp2, pp1
+    ])
+
+    @pp1
+    @pp3
+    @pp2
+    def get_page(self):
+        self.json.put({
+            'order': self.called_preprocessors,
+        })

--- a/tests/projects/test_app/pages/preprocessors/was_preprocessor_called.py
+++ b/tests/projects/test_app/pages/preprocessors/was_preprocessor_called.py
@@ -1,0 +1,36 @@
+from frontik.handler import PageHandler
+from frontik.preprocessors import preprocessor
+
+
+@preprocessor
+def pp0(handler):
+    pass
+
+
+@preprocessor
+def pp1(handler):
+    pass
+
+
+@preprocessor
+def pp2(handler):
+    pass
+
+
+@preprocessor
+def pp3(handler):
+    pass
+
+
+class Page(PageHandler):
+    preprocessors = [pp0]
+
+    @pp1
+    @pp2
+    def get_page(self):
+        self.json.put({
+            'pp0': self.was_preprocessor_called(pp0),
+            'pp1': self.was_preprocessor_called(pp1),
+            'pp2': self.was_preprocessor_called(pp2),
+            'pp3': self.was_preprocessor_called(pp3),
+        })

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -34,6 +34,27 @@ class TestPreprocessors(unittest.TestCase):
             }
         )
 
+    def test_was_preprocessor_called(self):
+        response_json = frontik_test_app.get_page_json('preprocessors/was_preprocessor_called')
+        self.assertEqual(
+            response_json,
+            {
+                'pp0': True,
+                'pp1': True,
+                'pp2': True,
+                'pp3': False,
+            }
+        )
+
+    def test_priority_preprocessors(self):
+        response_json = frontik_test_app.get_page_json('preprocessors/priority_preprocessors')
+        self.assertEqual(
+            response_json,
+            {
+                'order': ['pp0', 'pp2', 'pp1', 'pp3']
+            }
+        )
+
     def test_add_preprocessor_future_after_preprocessors(self):
         response = frontik_test_app.get_page('preprocessors/preprocessor_futures', method=requests.post)
         self.assertEqual(response.status_code, 500)


### PR DESCRIPTION
Добавил:
- Управление порядком вызова процессоров через  список свойства `priority_preprocessors_order` у хэнделра.
- Методы для прямого вызова препроцессоров и проверки, что они были вызваны
- Ссылку на обернутую в препроцессор функцию

Препроцессоры, зарегистрированные на методе хэндлера и перечисленные в свойстве `priority_preprocessors_order` вызываются по порядку перед остальными препроцессорами, зарегистрированными на данном методе.
Используется [здесь](https://github.com/hhru/hh.sites.main/pull/14245)