### PR TITLE
HH-127328 argument validation improvement

### DIFF
--- a/docs/arguments-validation.md
+++ b/docs/arguments-validation.md
@@ -1,17 +1,23 @@
 ## Argument validation
 To get arguments validated by type hints or specific validators you should use page handler method named `get_validated_argument`
-which is a wrapper for such methods as [`get_argument`, `get_arguments`, `get_body_argument`, `get_body_arguments`]. In case
-if argument fails validation then `HTTPErrorWithPostprocessors(404)` will raised 
+which is a wrapper for such methods as [`get_argument`, `get_arguments`, `get_body_argument`, `get_body_arguments`].
+
+Following logic applies for validation:
+- if default value is of incorrect type as specified by `validation` arg, then `DefaultValueError` will be raised, **even if valid value is present in request args**
+- `get_validated_argument` returns default value if argument value is invalid
+- if no default value is present then `HTTPErrorWithPostprocessors(http.client.BAD_REQUEST)` will be raised
+
+
 
 ```
-get_validated_argument(name, validation, default, from_body, array, strip) -> any
+get_validated_argument(name, validation, default, from_body, array, strip) -> Any
 ```
 * name `[str][required]` - name of argument
 * validation [ [Validators](https://github.com/hhru/frontik/blob/master/frontik/validator.py#L7) ] `[required]` - name of used validator (field of Enum)
-* default `[any]` - passes further as tornado `get_argument/get_arguments/get_body_argument/get_body_arguments` param
+* default `[any]` - must conform validator specified, passed further as tornado `get_argument/get_arguments/get_body_argument/get_body_arguments` param
 * from_body `[bool][default=False]` - flag for getting arguments from response body
 * array `[bool][default=False]` - flag for getting many arguments (i.g. like `get_arguments`)
-* strip `[bool][default=True]` - passes further as tornado `get_argument/get_body_argument` param
+* strip `[bool][default=True]` - passed further as tornado `get_argument/get_body_argument` param
 
 `get_validated argument` uses [BaseValidationModel](https://github.com/hhru/frontik/blob/master/frontik/validator.py#L17)
 as default model for validation.
@@ -37,7 +43,7 @@ class CustomValidationModel(BaseModel):
         return value
 
 def get_page(self):
-    self.set_validation_model(CustomValidationModel) 
+    self.set_validation_model(CustomValidationModel)
 ```
 
 
@@ -46,21 +52,21 @@ For shortening usage of `get_validated_argument` for specific types you can use 
 
 Get string argument:
 ```
-get_string_argument(name, path_safe) -> Optional[str]
+get_str_argument(name, path_safe) -> Union[str, List[str]]
 ```
 * path_safe`[bool][default=True]` - flag to use validator which detects dangerous symbols to pass to path
 
-Get int argument: 
+Get int argument:
 ```
-get_integer_argument(name) -> Optional[int]
+get_int_argument(name) -> Union[int, List[int]]
 ```
 
 Get bool argument:
 ```
-get_boolean_argument(name) -> Optional[bool]
+get_bool_argument(name) -> Union[bool, List[bool]]
 ```
- 
+
 Get float argument:
 ```
-get_float_argument(name) -> Optional[float]
-``` 
+get_float_argument(name) -> Union[float, List[float]]
+```

--- a/frontik/validator.py
+++ b/frontik/validator.py
@@ -23,8 +23,8 @@ class BaseValidationModel(BaseModel):
     list_str: Optional[List[str]]
     path_safe_string: Optional[str]
 
-    @validator('path_safe_string')
+    @validator('path_safe_string', pre=True)
     @classmethod
     def check_path_safe_string(cls, value):
-        assert '/' not in value
+        assert isinstance(value, str) and '/' not in value
         return value

--- a/tests/instances.py
+++ b/tests/instances.py
@@ -7,10 +7,9 @@ import time
 from distutils.spawn import find_executable
 
 import requests
+from frontik import options
 from lxml import etree
 from tornado.escape import to_unicode, utf8
-
-from frontik import options
 
 try:
     import coverage
@@ -109,24 +108,24 @@ class FrontikTestInstance:
 
         return method(url, **kwargs)
 
-    def get_page_xml(self, page, notpl=False, method=requests.get):
-        content = utf8(self.get_page(page, notpl=notpl, method=method).content)
+    def get_page_xml(self, page, notpl=False, method=requests.get, **kwargs):
+        content = utf8(self.get_page(page, notpl=notpl, method=method, **kwargs).content)
 
         try:
             return etree.fromstring(content)
         except Exception as e:
             raise Exception(f'failed to parse xml ({e}): "{content}"')
 
-    def get_page_json(self, page, notpl=False, method=requests.get):
-        content = self.get_page_text(page, notpl=notpl, method=method)
+    def get_page_json(self, page, notpl=False, method=requests.get, **kwargs):
+        content = self.get_page_text(page, notpl=notpl, method=method, **kwargs)
 
         try:
             return json.loads(content)
         except Exception as e:
             raise Exception(f'failed to parse json ({e}): "{content}"')
 
-    def get_page_text(self, page, notpl=False, method=requests.get):
-        return to_unicode(self.get_page(page, notpl=notpl, method=method).content)
+    def get_page_text(self, page, notpl=False, method=requests.get, **kwargs):
+        return to_unicode(self.get_page(page, notpl=notpl, method=method, **kwargs).content)
 
 
 common_frontik_start_options = f'--{options.STDERR_LOG_OPTION_NAME}=True'

--- a/tests/projects/test_app/pages/validate_arguments.py
+++ b/tests/projects/test_app/pages/validate_arguments.py
@@ -1,8 +1,8 @@
-from pydantic import validator
 from typing import Optional
 
 from frontik.handler import PageHandler
-from frontik.validator import Validators, BaseValidationModel
+from frontik.validator import BaseValidationModel, Validators
+from pydantic import validator
 
 
 class CustomModel(BaseValidationModel):
@@ -17,12 +17,34 @@ class CustomModel(BaseValidationModel):
 
 class Page(PageHandler):
     def get_page(self):
-        is_custom_model = self.get_boolean_argument('model', False)
+        is_custom_model = self.get_bool_argument('model', False)
+        empty_default_str = self.get_str_argument('str_arg_with_default', 'default')
+        empty_default_int = self.get_int_argument('int_arg_with_default', 0)
+        empty_str = self.get_str_argument('str_arg')
+        self.get_int_argument('int_arg')
 
         if is_custom_model:
             self.set_validation_model(CustomModel)
 
         list_int = self.get_validated_argument('list', Validators.LIST_INT, array=True)
-        string = self.get_string_argument('string', path_safe=not is_custom_model)
+        string = self.get_str_argument('string', path_safe=not is_custom_model)
 
-        self.json.put({'list': list_int, 'string': string})
+        self.json.put({
+            'list': list_int,
+            'string': string,
+            'str_arg_with_default': empty_default_str,
+            'int_arg_with_default': empty_default_int,
+            'str_arg': empty_str,
+        })
+
+    def post_page(self):
+        str_body_arg = self.get_str_argument('str_argument', 'default', from_body=True)
+        int_body_arg = self.get_int_argument('int_argument', 0, from_body=True)
+
+        self.json.put({
+            'str_body_arg': str_body_arg,
+            'int_body_arg': int_body_arg,
+        })
+
+    def put_page(self):
+        self.get_str_argument('str_arg', 3)

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -1,25 +1,70 @@
-import json
 import unittest
+from urllib.parse import urlencode
+
+import requests
 
 from .instances import frontik_test_app
 
 
 class TestJsonResponse(unittest.TestCase):
-    def test_validation(self):
-        response = frontik_test_app.get_page('validate_arguments?list=1&list=2&string=safestring', notpl=True)
 
-        data = json.loads(response.content)
-        self.assertEqual([1, 2], data['list'])
-        self.assertEqual('safestring', data['string'])
+    def setUp(self) -> None:
+        self.query_args = {
+            'list': [1, 2],
+            'string': 'safestring',
+            'str_arg': '',
+            'int_arg_with_default': '',
+            'int_arg': '',
+        }
+        return super().setUp()
+
+    def test_validation(self):
+
+        self.query_args.update(int_arg=0)
+        get_data = frontik_test_app.get_page_json(
+            f'validate_arguments?{urlencode(self.query_args, doseq=True)}',
+            notpl=True
+        )
+
+        self.assertEqual([1, 2], get_data['list'])
+        self.assertEqual('safestring', get_data['string'])
+        self.assertEqual('', get_data['str_arg'])
+        self.assertEqual('default', get_data['str_arg_with_default'])
+        self.assertEqual(0, get_data['int_arg_with_default'])
+
+        post_data = frontik_test_app.get_page_json(
+            'validate_arguments',
+            notpl=True,
+            method=requests.post,
+            data=self.query_args,
+        )
+        self.assertEqual('default', post_data['str_body_arg'])
+        self.assertEqual(0, post_data['int_body_arg'])
 
     def test_validation_failed(self):
-        response = frontik_test_app.get_page('validate_arguments?list=1&list=2&string=un/safe', notpl=True)
+        self.query_args.update(string='un/safe')
+        response = frontik_test_app.get_page(f'validate_arguments?{urlencode(self.query_args, doseq=True)}', notpl=True)
 
         self.assertEqual(response.status_code, 400)
 
-    def test_validation_model(self):
-        response = frontik_test_app.get_page('validate_arguments?list=1&list=2&string=nword&model=true', notpl=True)
+    def test_arg_validation_raises_for_empty_value_with_no_default(self):
+        response = frontik_test_app.get_page(f'validate_arguments?{urlencode(self.query_args, doseq=True)}', notpl=True)
 
-        data = json.loads(response.content)
+        self.assertEqual(response.status_code, 400)
+
+    def test_arg_validation_raises_for_default_of_incorrect_type(self):
+        response = frontik_test_app.get_page('validate_arguments?str_arg=test', method=requests.put, notpl=True)
+
+        self.assertEqual(response.status_code, 500)
+
+    def test_validation_model(self):
+        self.query_args.update(int_arg=0)
+        self.query_args.update(model=True)
+
+        data = frontik_test_app.get_page_json(
+            f'validate_arguments?{urlencode(self.query_args, doseq=True)}',
+            notpl=True
+        )
+
         self.assertEqual([1, 2], data['list'])
         self.assertEqual('customString', data['string'])


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-127328
Решаю проблему ,когда `get_validated_argument()` вызывается на квере следующего вида:
`some_value=123&empty_value=`, в текущей реализации empty_value будет иметь значение `''`, что не позволит использовать дефолт, но не пройдет валидацию на `int()`

- поменял имена у методов, чтобы они соответствовали именам питонячих типов
- обновил доку
- добавил проверку дефолтного значения на соответствие валидатору
- валидация теперь всегда пытается вернуть значение по умолчанию