### PR TITLE
HH-138216 Improve AwaitablePH

### DIFF
--- a/frontik/util.py
+++ b/frontik/util.py
@@ -1,6 +1,8 @@
+import asyncio
 import mimetypes
 import os.path
 import re
+from typing import Dict, Awaitable
 from urllib.parse import urlencode
 from uuid import uuid4
 
@@ -173,3 +175,8 @@ def get_abs_path(root_path, relative_path):
         return relative_path
 
     return os.path.normpath(os.path.join(root_path, relative_path))
+
+
+async def gather_dict(coro_dict: Dict[str, Awaitable]):
+    results = await asyncio.gather(*coro_dict.values())
+    return dict(zip(coro_dict.keys(), results))


### PR DESCRIPTION
Добавила несколько полезных методов:
* def run_task(self: 'AwaitablePageHandler', coro: Awaitable, waited=True) - создает asyncio-таску, то есть задача **в месте вызова** сразу ставится на выполнение на event-loop и авейтится в finish_group перед отдачей ответа (если нет флага waited=False). В общем случае, ее не нужно авейтить - она и так выполнится. Однако, мы можем сохранить таску в переменную и дождаться ее выполнения ниже (такие кейсы есть для некоторых препроцессоров, где надо в ответ положить какие-то данные, и кроме этого на **отдельных** страницах надо эти данные как-то дополнительно обработать).
```python
# в препроцессоре
self.target_task = self.run_task(coro())  # она пошла выполняться и будет в любом случае заавейчена в finish_group 
.....
# ниже в коде на нужных страницах мы можем заавейтить ее раньше finish_group если это требуется
result = await self.target_task
# обрабатываем как-то result
```
когда полезно:
1,2,3  корутины содержат походы в сервис, обработку его ответа и подмешивание в итоговый ответ. Они полностью независимы. Далее идет сложный разветвленный код.

```python
# в начале хендлера
self.run_task(coro_1())
self.run_task(coro_2())
self.run_task(coro_3())

await asyncio.gather(
    coro_4(),
    coro_5()
)
# .... обработка 4,5
await coro_7()
if False:
    await asyncio.gather(
        coro_8(),
        coro_9()
    )
```
Если мы и первые корутины запихнем в gather, то такой код будет очень сложно читать

* def put_xml_to_response(self: 'AwaitablePageHandler', request_coro: Awaitable)
* async def gather_dict(self: 'AwaitablePageHandler', coro_dict: Dict[str, Awaitable]):