### PR TITLE
HH-139502 raise 400 if mandatory cookie is invalid

### DIFF
--- a/frontik/handler.py
+++ b/frontik/handler.py
@@ -567,7 +567,10 @@ class PageHandler(RequestHandler):
             self.set_header(name, value)
 
         for args, kwargs in self._mandatory_cookies.values():
-            self.set_cookie(*args, **kwargs)
+            try:
+                self.set_cookie(*args, **kwargs)
+            except ValueError:
+                self.set_status(http.client.BAD_REQUEST)
 
         if self._status_code in (204, 304) or (100 <= self._status_code < 200):
             self._write_buffer = []

--- a/tests/projects/test_app/pages/mandatory_headers.py
+++ b/tests/projects/test_app/pages/mandatory_headers.py
@@ -27,3 +27,7 @@ class Page(PageHandler):
             self.clear_header('TEST_HEADER')
             self.clear_cookie('TEST_COOKIE')
             raise HTTPError(500)
+
+        elif self.get_argument('test_invalid_mandatory_cookie') is not None:
+            self.set_mandatory_cookie('TEST_COOKIE', '<!--#include file="/etc/passwd"-->')
+            raise HTTPError(500)

--- a/tests/test_mandatory_headers.py
+++ b/tests/test_mandatory_headers.py
@@ -27,3 +27,8 @@ class TestPostprocessors(unittest.TestCase):
         self.assertEqual(response.status_code, 500)
         self.assertIsNone(response.headers.get('TEST_HEADER'))
         self.assertIsNone(response.headers.get('TEST_COOKIE'))
+
+    def test_invalid_mandatory_cookie(self):
+        response = frontik_test_app.get_page('mandatory_headers?test_invalid_mandatory_cookie')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.headers.get('TEST_COOKIE'), None)


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-139502

### Проблема

если в hhuid невалидная кука, то упадет page.finish, потому что он ставится через set_mandatory_cookie, который не вызывает set_cookie сразу, а откладывает до финиша 

### Решение

кидаем хакерам 400