### PR TITLE
HH-158763 add consul metrics sending

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -32,28 +32,29 @@ These options can be set for each Frontik instance (see [options.py](/frontik/op
 
 Logging options:
 
-| Option name                            | Type    | Default value | Description                                                            |
-|----------------------------------------|---------|---------------|------------------------------------------------------------------------|
-| `log_level`                            | `str`   | `info`        | Python log level                                                       |
-| `logformat`                            | `str`   | see code      | Log entry format for files and syslog                                  |
-| `log_dir`                              | `str`   | `None`        | Log directory location (set to `None` to disable logging to file)      |
-| `log_json`                             | `bool`  | `True`        | Enable JSON logging for files and syslog                               |
-| `log_text_format`                      | `str`   | see code      | Log format for files and syslog when JSON logging is disabled          |
-| `stderr_log`                           | `bool`  | `False`       | Send log output to stderr (colorized if possible)                      |
-| `stderr_format`                        | `str`   | see code      | Log entry format for stderr output                                     |
-| `stderr_dateformat`                    | `str`   | see code      | Log entry date format for stderr output                                |
-| `syslog`                               | `bool`  | `False`       | Enables sending logs to syslog                                         |
-| `syslog_host`                          | `str`   | `127.0.0.1`   | Syslog host                                                            |
-| `syslog_port`                          | `int`   | `None`        | Syslog port. If this value is None, unix socket is used, UDP otherwise |
-| `syslog_facility`                      | `str`   | `'user'`      | Syslog facility                                                        |
-| `suppressed_loggers`                   | `list`  | `[]`          | List of logger names to be excluded from debug output                  |
-| `sentry_dsn`                           | `str`   | `None`        | Enable Sentry and set Sentry DSN for sending errors                    |
-| `sentry_connect_timeout_sec`           | `float` | `0.2`         | Sentry connect timeout                                                 |
-| `sentry_request_timeout_sec`           | `float` | `2.0`         | sentry request timeout                                                 |
-| `statsd_host`                          | `str`   | `None`        | Stats server host for metrics                                          |
-| `statsd_port`                          | `int`   | `None`        | Stats server port for metrics                                          |
-| `asyncio_task_threshold_sec`           | `float` | `None`        | Threshold for logging long-running asyncio tasks                       |
-| `asyncio_task_critical_threshold_sec`  | `float` | `None`        | Threshold for send to Sentry long-running asyncio tasks                |
+| Option name                                 | Type    | Default value | Description                                                            |
+|---------------------------------------------|---------|---------------|------------------------------------------------------------------------|
+| `log_level`                                 | `str`   | `info`        | Python log level                                                       |
+| `logformat`                                 | `str`   | see code      | Log entry format for files and syslog                                  |
+| `log_dir`                                   | `str`   | `None`        | Log directory location (set to `None` to disable logging to file)      |
+| `log_json`                                  | `bool`  | `True`        | Enable JSON logging for files and syslog                               |
+| `log_text_format`                           | `str`   | see code      | Log format for files and syslog when JSON logging is disabled          |
+| `stderr_log`                                | `bool`  | `False`       | Send log output to stderr (colorized if possible)                      |
+| `stderr_format`                             | `str`   | see code      | Log entry format for stderr output                                     |
+| `stderr_dateformat`                         | `str`   | see code      | Log entry date format for stderr output                                |
+| `syslog`                                    | `bool`  | `False`       | Enables sending logs to syslog                                         |
+| `syslog_host`                               | `str`   | `127.0.0.1`   | Syslog host                                                            |
+| `syslog_port`                               | `int`   | `None`        | Syslog port. If this value is None, unix socket is used, UDP otherwise |
+| `syslog_facility`                           | `str`   | `'user'`      | Syslog facility                                                        |
+| `suppressed_loggers`                        | `list`  | `[]`          | List of logger names to be excluded from debug output                  |
+| `sentry_dsn`                                | `str`   | `None`        | Enable Sentry and set Sentry DSN for sending errors                    |
+| `sentry_connect_timeout_sec`                | `float` | `0.2`         | Sentry connect timeout                                                 |
+| `sentry_request_timeout_sec`                | `float` | `2.0`         | sentry request timeout                                                 |
+| `statsd_host`                               | `str`   | `None`        | Stats server host for metrics                                          |
+| `statsd_port`                               | `int`   | `None`        | Stats server port for metrics                                          |
+| `statsd_default_periodic_send_interval_sec` | `int`   | `60`          | Stats default periodic metrics sending interval                        |
+| `asyncio_task_threshold_sec`                | `float` | `None`        | Threshold for logging long-running asyncio tasks                       |
+| `asyncio_task_critical_threshold_sec`       | `float` | `None`        | Threshold for send to Sentry long-running asyncio tasks                |
 
 HTTP client options:
 

--- a/frontik/consul.py
+++ b/frontik/consul.py
@@ -1,0 +1,149 @@
+import sys
+import asyncio
+import warnings
+import requests
+
+import aiohttp
+from aiohttp import ClientTimeout
+
+from consul import base
+
+
+PY_341 = sys.version_info >= (3, 4, 1)
+
+
+class AsyncConsul(base.Consul):
+    def __init__(self, *args, loop=None, **kwargs):
+        self._loop = loop or asyncio.get_event_loop()
+        super().__init__(*args, **kwargs)
+
+    def http_connect(self, host, port, scheme, verify=True, cert=None):
+        return _AsyncConsulHttpClient(host, port, scheme, loop=self._loop,
+                                      verify=verify, cert=None)
+
+
+class SyncConsul(base.Consul):
+    @staticmethod
+    def http_connect(host, port, scheme, verify=True, cert=None, timeout=None):
+        return _SyncConsulHttpClient(host, port, scheme, verify, cert, timeout)
+
+
+class _AsyncConsulHttpClient(base.HTTPClient):
+    """Asyncio adapter for python consul using aiohttp library"""
+
+    def __init__(self, *args, loop=None, **kwargs):
+        super(_AsyncConsulHttpClient, self).__init__(*args, **kwargs)
+        self._session = None
+        self._loop = loop or asyncio.get_event_loop()
+
+    async def _request(self, callback, method, uri, data=None, headers=None, total_timeout=None):
+        connector = aiohttp.TCPConnector(loop=self._loop,
+                                         verify_ssl=self.verify)
+        async with aiohttp.ClientSession(connector=connector, timeout=ClientTimeout(total=total_timeout)) as session:
+            self._session = session
+            resp = await session.request(method=method,
+                                         url=uri,
+                                         data=data,
+                                         headers=headers)
+            body = await resp.text(encoding='utf-8')
+            content = await resp.read()
+            if resp.status == 599:
+                raise base.Timeout
+            r = base.Response(resp.status, resp.headers, body, content)
+            await session.close()
+            return callback(r)
+
+    # python prior 3.4.1 does not play nice with __del__ method
+    if PY_341:  # pragma: no branch
+        def __del__(self):
+            warnings.warn("Unclosed connector in aio.Consul.HTTPClient",
+                          ResourceWarning)
+            if self._session and not self._session.closed:
+                warnings.warn("Unclosed connector in aio.Consul.HTTPClient",
+                              ResourceWarning)
+                asyncio.ensure_future(self.close())
+
+    async def get(self, callback, path, params=None, headers=None, total_timeout=None):
+        uri = self.uri(path, params)
+        return await self._request(callback, 'GET', uri, headers=headers, total_timeout=total_timeout)
+
+    async def put(self, callback, path, params=None, data='', headers=None):
+        uri = self.uri(path, params)
+        return await self._request(callback,
+                                   'PUT',
+                                   uri,
+                                   data=data,
+                                   headers=headers)
+
+    async def delete(self, callback, path, params=None, data='', headers=None):
+        uri = self.uri(path, params)
+        return await self._request(callback,
+                                   'DELETE',
+                                   uri,
+                                   data=data,
+                                   headers=headers)
+
+    async def post(self, callback, path, params=None, data='', headers=None):
+        uri = self.uri(path, params)
+        return await self._request(callback,
+                                   'POST',
+                                   uri,
+                                   data=data,
+                                   headers=headers)
+
+    async def close(self):
+        await self._session.close()
+
+
+class _SyncConsulHttpClient(base.HTTPClient):
+    def __init__(self, *args, **kwargs):
+        super(_SyncConsulHttpClient, self).__init__(*args, **kwargs)
+        self.session = requests.session()
+
+    @staticmethod
+    def response(response):
+        response.encoding = 'utf-8'
+        return base.Response(
+            response.status_code,
+            response.headers,
+            response.text,
+            response.content)
+
+    def get(self, callback, path, params=None, headers=None, total_timeout=None):
+        uri = self.uri(path, params)
+        return callback(self.response(
+            self.session.get(uri,
+                             headers=headers,
+                             verify=self.verify,
+                             cert=self.cert,
+                             timeout=self.timeout)))
+
+    def put(self, callback, path, params=None, data='', headers=None):
+        uri = self.uri(path, params)
+        return callback(self.response(
+            self.session.put(uri,
+                             data=data,
+                             headers=headers,
+                             verify=self.verify,
+                             cert=self.cert,
+                             timeout=self.timeout)))
+
+    def delete(self, callback, path, params=None, data='', headers=None):
+        uri = self.uri(path, params)
+        return callback(self.response(
+            self.session.delete(uri,
+                                data=data,
+                                headers=headers,
+                                verify=self.verify,
+                                cert=self.cert,
+                                timeout=self.timeout)))
+
+    def post(self, callback, path, params=None, headers=None, data=''):
+        uri = self.uri(path, params)
+        return callback(self.response(
+            self.session.post(uri,
+                              data=data,
+                              headers=headers,
+                              verify=self.verify,
+                              cert=self.cert,
+                              timeout=self.timeout)))

--- a/frontik/consul_client.py
+++ b/frontik/consul_client.py
@@ -38,6 +38,8 @@ class SyncConsulClient(ConsulClient):
                                      client_event_callback=self._client_event_callback)
 
 
+# this implementation was copied from https://github.com/hhru/python-consul2/blob/master/consul/aio.py#L16
+# and then _client_event_callback was added
 class _AsyncConsulHttpClient(base.HTTPClient):
     """Asyncio adapter for python consul using aiohttp library"""
 
@@ -120,6 +122,8 @@ class _AsyncConsulHttpClient(base.HTTPClient):
         await self._session.close()
 
 
+# this implementation was copied from https://github.com/hhru/python-consul2/blob/master/consul/std.py#L8
+# and then _client_event_callback was added
 class _SyncConsulHttpClient(base.HTTPClient):
     def __init__(self, *args, client_event_callback, **kwargs):
         super(_SyncConsulHttpClient, self).__init__(*args, **kwargs)

--- a/frontik/consul_client.py
+++ b/frontik/consul_client.py
@@ -16,13 +16,13 @@ HTTP_METHOD_PUT = "PUT"
 HTTP_METHOD_DELETE = "DELETE"
 
 
-class Consul(base.Consul):
+class ConsulClient(base.Consul):
     def __init__(self, *args, client_event_callback=None, **kwargs):
         self._client_event_callback = ClientEventCallback() if client_event_callback is None else client_event_callback
         super().__init__(*args, **kwargs)
 
 
-class AsyncConsul(Consul):
+class AsyncConsulClient(ConsulClient):
     def __init__(self, *args, loop=None, client_event_callback=None, **kwargs):
         self._loop = loop or asyncio.get_event_loop()
         super().__init__(*args, client_event_callback=client_event_callback, **kwargs)
@@ -32,7 +32,7 @@ class AsyncConsul(Consul):
                                       client_event_callback=self._client_event_callback)
 
 
-class SyncConsul(Consul):
+class SyncConsulClient(ConsulClient):
     def http_connect(self, host, port, scheme, verify=True, cert=None, timeout=None):
         return _SyncConsulHttpClient(host, port, scheme, verify, cert, timeout,
                                      client_event_callback=self._client_event_callback)

--- a/frontik/integrations/statsd.py
+++ b/frontik/integrations/statsd.py
@@ -1,9 +1,10 @@
 import socket
 import collections
+import threading
+import time
+from functools import partial
 from asyncio import Future
 from typing import Optional
-
-from tornado.ioloop import IOLoop
 
 from frontik.integrations import Integration, integrations_logger
 from frontik.options import options
@@ -14,14 +15,7 @@ class StatsdIntegration(Integration):
         self.statsd_client = None
 
     def initialize_app(self, app) -> Optional[Future]:
-        if options.statsd_host is None or options.statsd_port is None:
-            self.statsd_client = StatsDClientStub()
-            integrations_logger.info(
-                'statsd integration is disabled: statsd_host / statsd_port options are not configured'
-            )
-        else:
-            self.statsd_client = StatsDClient(options.statsd_host, options.statsd_port, app=app.app)
-
+        self.statsd_client = create_statsd_client(options, app)
         app.statsd_client = self.statsd_client
         return None
 
@@ -44,6 +38,24 @@ def _encode_str(some):
     return some if isinstance(some, (bytes, bytearray)) else some.encode('utf-8')
 
 
+class Counters:
+    def __init__(self):
+        self._metrics = {}
+        self._lock = threading.Lock()
+
+    def add(self, value, **kwargs):
+        with self._lock:
+            tags = tuple(sorted(kwargs.items()))
+            self._metrics.setdefault(tags, 0)
+            self._metrics[tags] += value
+
+    def get_snapshot_and_reset(self):
+        with self._lock:
+            snapshot = self._metrics
+            self._metrics = {}
+            return snapshot.items()
+
+
 class StatsDClientStub:
     def __init__(self):
         pass
@@ -57,17 +69,24 @@ class StatsDClientStub:
     def count(self, aspect, delta, **kwargs):
         pass
 
+    def counters(self, aspect, counters):
+        pass
+
     def time(self, aspect, value, **kwargs):
         pass
 
     def gauge(self, aspect, value, **kwargs):
         pass
 
+    def send_periodically(self, callback, send_interval_sec=None):
+        pass
+
 
 class StatsDClient:
-    def __init__(self, host, port, app=None, max_udp_size=508, reconnect_timeout=2):
+    def __init__(self, host, port, default_periodic_send_interval_sec, app=None, max_udp_size=508, reconnect_timeout=2):
         self.host = host
         self.port = port
+        self.default_periodic_send_interval_sec = default_periodic_send_interval_sec
         self.app = app
         self.max_udp_size = max_udp_size
         self.reconnect_timeout = reconnect_timeout
@@ -93,7 +112,7 @@ class StatsDClient:
     def _close(self):
         self.socket.close()
         self.socket = None
-        IOLoop.current().add_timeout(IOLoop.current().time() + self.reconnect_timeout, self._connect)
+        threading.Timer(self.reconnect_timeout, self._connect).start()
 
     def _send(self, message):
         if len(message) > self.max_udp_size:
@@ -143,8 +162,38 @@ class StatsDClient:
     def count(self, aspect, delta, **kwargs):
         self._send('{}{}:{}|c'.format(aspect, _convert_tags(dict(kwargs, app=self.app)), delta))
 
+    def counters(self, aspect, counters):
+        for tags, count in counters.get_snapshot_and_reset():
+            self.count(aspect, count, **dict(tags))
+
     def time(self, aspect, value, **kwargs):
         self._send('{}{}:{}|ms'.format(aspect, _convert_tags(dict(kwargs, app=self.app)), value))
 
     def gauge(self, aspect, value, **kwargs):
         self._send('{}{}:{}|g'.format(aspect, _convert_tags(dict(kwargs, app=self.app)), value))
+
+    def send_periodically(self, callback, send_interval_sec=None):
+        if send_interval_sec is None:
+            send_interval_sec = self.default_periodic_send_interval_sec
+        threading.Thread(target=partial(self._send_periodically, callback, send_interval_sec), daemon=True).start()
+
+    @staticmethod
+    def _send_periodically(callback, send_interval_sec):
+        while True:
+            try:
+                time.sleep(send_interval_sec)
+                callback()
+            except Exception as e:
+                integrations_logger.warning('statsd: writing error: %s', e)
+
+
+def create_statsd_client(options, app):
+    if options.statsd_host is None or options.statsd_port is None:
+        statsd_client = StatsDClientStub()
+        integrations_logger.info(
+            'statsd integration is disabled: statsd_host / statsd_port options are not configured'
+        )
+    else:
+        statsd_client = StatsDClient(options.statsd_host, options.statsd_port,
+                                     options.statsd_default_periodic_send_interval_sec, app=app.app)
+    return statsd_client

--- a/frontik/integrations/statsd.py
+++ b/frontik/integrations/statsd.py
@@ -40,20 +40,17 @@ def _encode_str(some):
 
 class Counters:
     def __init__(self):
-        self._metrics = {}
-        self._lock = threading.Lock()
+        self._tags_to_counter = {}
 
     def add(self, value, **kwargs):
-        with self._lock:
-            tags = tuple(sorted(kwargs.items()))
-            self._metrics.setdefault(tags, 0)
-            self._metrics[tags] += value
+        tags = tuple(sorted(kwargs.items()))
+        self._tags_to_counter.setdefault(tags, 0)
+        self._tags_to_counter[tags] += value
 
     def get_snapshot_and_reset(self):
-        with self._lock:
-            snapshot = self._metrics
-            self._metrics = {}
-            return snapshot.items()
+        snapshot = self._tags_to_counter
+        self._tags_to_counter = {}
+        return snapshot.items()
 
 
 class StatsDClientStub:

--- a/frontik/options.py
+++ b/frontik/options.py
@@ -56,6 +56,7 @@ class Options:
 
     statsd_host: str = None
     statsd_port: int = None
+    statsd_default_periodic_send_interval_sec: int = 60
     gc_metrics_send_interval_ms: int = None
 
     xml_root: str = None

--- a/frontik/process.py
+++ b/frontik/process.py
@@ -61,7 +61,6 @@ def fork_workers(worker_function, *, app, init_workers_count_down, num_workers, 
                 f' do not started {init_workers_count_down.value} workers'
             )
         time.sleep(0.1)
-    app.upstream_caches.send_updates()
     after_workers_up_action()
     _supervise_workers(state, worker_function)
 

--- a/frontik/service_discovery.py
+++ b/frontik/service_discovery.py
@@ -15,7 +15,7 @@ from consul.base import Check, Weight, KVCache, ConsistencyMode, HealthCache
 from http_client import consul_parser, Upstream, options as http_client_options
 from tornado.iostream import PipeIOStream, StreamClosedError
 
-from frontik.consul import AsyncConsul, SyncConsul, ClientEventCallback
+from frontik.consul_client import AsyncConsulClient, SyncConsulClient, ClientEventCallback
 from frontik.integrations.statsd import Counters
 from frontik.options import options
 from frontik.version import version
@@ -91,10 +91,10 @@ def _get_hostname_or_raise(node_name: str):
 class _AsyncServiceDiscovery:
     def __init__(self, options, statsd_client, event_loop=None):
         self.options = options
-        self.consul = AsyncConsul(host=options.consul_host,
-                                  port=options.consul_port,
-                                  loop=event_loop,
-                                  client_event_callback=ConsulMetricsTracker(statsd_client))
+        self.consul = AsyncConsulClient(host=options.consul_host,
+                                        port=options.consul_port,
+                                        loop=event_loop,
+                                        client_event_callback=ConsulMetricsTracker(statsd_client))
         self.service_name = options.app
         self.hostname = _get_hostname_or_raise(options.node_name)
         self.service_id = _make_service_id(options, service_name=self.service_name, hostname=self.hostname)
@@ -143,9 +143,9 @@ class _AsyncServiceDiscovery:
 class _SyncServiceDiscovery:
     def __init__(self, options, statsd_client):
         self.options = options
-        self.consul = SyncConsul(host=options.consul_host,
-                                 port=options.consul_port,
-                                 client_event_callback=ConsulMetricsTracker(statsd_client))
+        self.consul = SyncConsulClient(host=options.consul_host,
+                                       port=options.consul_port,
+                                       client_event_callback=ConsulMetricsTracker(statsd_client))
         self.service_name = options.app
         self.hostname = _get_hostname_or_raise(options.node_name)
         self.service_id = _make_service_id(options, service_name=self.service_name, hostname=self.hostname)

--- a/frontik/service_discovery.py
+++ b/frontik/service_discovery.py
@@ -11,9 +11,8 @@ from threading import Lock, Thread
 from queue import Queue, Full
 
 import asyncio
-from consul import Check, Consul
-from consul.aio import Consul as AsyncConsul
-from consul.base import Weight, KVCache, ConsistencyMode, HealthCache
+from frontik.consul import AsyncConsul, SyncConsul
+from consul.base import Check, Weight, KVCache, ConsistencyMode, HealthCache
 from http_client import consul_parser, Upstream, options as http_client_options
 from tornado.iostream import PipeIOStream, StreamClosedError
 
@@ -136,7 +135,7 @@ class _AsyncServiceDiscovery:
 class _SyncServiceDiscovery:
     def __init__(self, options):
         self.options = options
-        self.consul = Consul(host=options.consul_host, port=options.consul_port)
+        self.consul = SyncConsul(host=options.consul_host, port=options.consul_port)
         self.service_name = options.app
         self.hostname = _get_hostname_or_raise(options.node_name)
         self.service_id = _make_service_id(options, service_name=self.service_name, hostname=self.hostname)

--- a/frontik/service_discovery.py
+++ b/frontik/service_discovery.py
@@ -11,11 +11,12 @@ from threading import Lock, Thread
 from queue import Queue, Full
 
 import asyncio
-from frontik.consul import AsyncConsul, SyncConsul
 from consul.base import Check, Weight, KVCache, ConsistencyMode, HealthCache
 from http_client import consul_parser, Upstream, options as http_client_options
 from tornado.iostream import PipeIOStream, StreamClosedError
 
+from frontik.consul import AsyncConsul, SyncConsul, ClientEventCallback
+from frontik.integrations.statsd import Counters
 from frontik.options import options
 from frontik.version import version
 
@@ -23,6 +24,10 @@ DEFAULT_WEIGHT = 100
 AUTO_RESOLVE_ADDRESS_VALUE = 'resolve'
 MESSAGE_HEADER_MAGIC = b'T1uf31f'
 MESSAGE_SIZE_STRUCT = '=Q'
+
+CONSUL_REQUESTS_METRIC = "consul.request"
+CONSUL_REQUEST_SUCCESSFUL_RESULT = "success"
+CONSUL_REQUEST_FAILED_RESULT = "failure"
 
 log = logging.getLogger('service_discovery')
 
@@ -35,20 +40,20 @@ def _get_service_address(options):
         return options.consul_service_address
 
 
-def get_async_service_discovery(opts, *, event_loop=None):
+def get_async_service_discovery(opts, statsd_client, *, event_loop=None):
     if not opts.consul_enabled:
         log.info('Consul disabled, skipping')
         return _AsyncStub()
     else:
-        return _AsyncServiceDiscovery(opts, event_loop)
+        return _AsyncServiceDiscovery(opts, statsd_client, event_loop)
 
 
-def get_sync_service_discovery(opts):
+def get_sync_service_discovery(opts, statsd_client):
     if not opts.consul_enabled:
         log.info('Consul disabled, skipping')
         return _SyncStub()
     else:
-        return _SyncServiceDiscovery(opts)
+        return _SyncServiceDiscovery(opts, statsd_client)
 
 
 def _make_service_id(options, *, service_name, hostname):
@@ -84,9 +89,12 @@ def _get_hostname_or_raise(node_name: str):
 
 
 class _AsyncServiceDiscovery:
-    def __init__(self, options, event_loop=None):
+    def __init__(self, options, statsd_client, event_loop=None):
         self.options = options
-        self.consul = AsyncConsul(host=options.consul_host, port=options.consul_port, loop=event_loop)
+        self.consul = AsyncConsul(host=options.consul_host,
+                                  port=options.consul_port,
+                                  loop=event_loop,
+                                  client_event_callback=ConsulMetricsTracker(statsd_client))
         self.service_name = options.app
         self.hostname = _get_hostname_or_raise(options.node_name)
         self.service_id = _make_service_id(options, service_name=self.service_name, hostname=self.hostname)
@@ -133,9 +141,11 @@ class _AsyncServiceDiscovery:
 
 
 class _SyncServiceDiscovery:
-    def __init__(self, options):
+    def __init__(self, options, statsd_client):
         self.options = options
-        self.consul = SyncConsul(host=options.consul_host, port=options.consul_port)
+        self.consul = SyncConsul(host=options.consul_host,
+                                 port=options.consul_port,
+                                 client_event_callback=ConsulMetricsTracker(statsd_client))
         self.service_name = options.app
         self.hostname = _get_hostname_or_raise(options.node_name)
         self.service_id = _make_service_id(options, service_name=self.service_name, hostname=self.hostname)
@@ -207,6 +217,29 @@ class _SyncStub:
         pass
 
 
+class ConsulMetricsTracker(ClientEventCallback):
+
+    def __init__(self, statsd_client):
+        self._statsd_client = statsd_client
+        self._request_counters = Counters()
+        self._statsd_client.send_periodically(self._send_metrics)
+
+    def on_http_request_success(self, method, path, response_code):
+        self._request_counters.add(1, method=method, url=path, result=CONSUL_REQUEST_SUCCESSFUL_RESULT,
+                                   type=response_code)
+
+    def on_http_request_failure(self, method, path, ex):
+        self._request_counters.add(1, method=method, url=path, result=CONSUL_REQUEST_FAILED_RESULT,
+                                   type=type(ex).__name__)
+
+    def on_http_request_invalid(self, method, path, response_code):
+        self._request_counters.add(1, method=method, url=path, result=CONSUL_REQUEST_FAILED_RESULT,
+                                   type=response_code)
+
+    def _send_metrics(self):
+        self._statsd_client.counters(CONSUL_REQUESTS_METRIC, self._request_counters)
+
+
 class UpstreamUpdateListener:
     def __init__(self, http_client_factory, pipe):
         self.http_client_factory = http_client_factory
@@ -233,7 +266,7 @@ class UpstreamUpdateListener:
 
 
 class UpstreamCaches:
-    def __init__(self, children_pipes, upstreams):
+    def __init__(self, children_pipes, upstreams, service_discovery=None):
         self._upstreams_config = {}
         self._upstreams_servers = {}
         self._upstream_list = options.upstreams
@@ -248,41 +281,40 @@ class UpstreamCaches:
         self._resend_notification = Queue(maxsize=1)
         self._resend_thread = Thread(target=self._resend, daemon=True)
 
-    def initial_upstreams_caches(self):
-        self._resend_thread.start()
+        if service_discovery is not None:
+            self._resend_thread.start()
 
-        service_discovery = get_sync_service_discovery(options)
-        upstream_cache = KVCache(
-            service_discovery.consul.kv,
-            path='upstream/',
-            watch_seconds=service_discovery.consul_weight_watch_seconds,
-            backoff_delay_seconds=service_discovery.consul_cache_backoff_delay_seconds,
-            total_timeout=service_discovery.consul_weight_total_timeout_sec,
-            cache_initial_warmup_timeout=service_discovery.consul_cache_initial_warmup_timeout_sec,
-            consistency_mode=service_discovery.consul_weight_consistency_mode,
-            recurse=True,
-            caller=self._service_name
-        )
-        upstream_cache.add_listener(self._update_upstreams_config, True)
-        upstream_cache.start()
+            upstream_cache = KVCache(
+                service_discovery.consul.kv,
+                path='upstream/',
+                watch_seconds=service_discovery.consul_weight_watch_seconds,
+                backoff_delay_seconds=service_discovery.consul_cache_backoff_delay_seconds,
+                total_timeout=service_discovery.consul_weight_total_timeout_sec,
+                cache_initial_warmup_timeout=service_discovery.consul_cache_initial_warmup_timeout_sec,
+                consistency_mode=service_discovery.consul_weight_consistency_mode,
+                recurse=True,
+                caller=self._service_name
+            )
+            upstream_cache.add_listener(self._update_upstreams_config, True)
+            upstream_cache.start()
 
-        for upstream in self._upstream_list:
-            datacenters = self._datacenter_list if self._allow_cross_dc_requests else (self._current_dc,)
-            for dc in datacenters:
-                health_cache = HealthCache(
-                    service=upstream,
-                    health_client=service_discovery.consul.health,
-                    passing=True,
-                    watch_seconds=service_discovery.consul_weight_watch_seconds,
-                    backoff_delay_seconds=service_discovery.consul_cache_backoff_delay_seconds,
-                    dc=dc,
-                    caller=self._service_name
-                )
-                health_cache.add_listener(self._update_upstreams_service, True)
-                health_cache.start()
+            for upstream in self._upstream_list:
+                datacenters = self._datacenter_list if self._allow_cross_dc_requests else (self._current_dc,)
+                for dc in datacenters:
+                    health_cache = HealthCache(
+                        service=upstream,
+                        health_client=service_discovery.consul.health,
+                        passing=True,
+                        watch_seconds=service_discovery.consul_weight_watch_seconds,
+                        backoff_delay_seconds=service_discovery.consul_cache_backoff_delay_seconds,
+                        dc=dc,
+                        caller=self._service_name
+                    )
+                    health_cache.add_listener(self._update_upstreams_service, True)
+                    health_cache.start()
 
-        if options.fail_start_on_empty_upstream:
-            self._check_empty_upstreams_on_startup()
+            if options.fail_start_on_empty_upstream:
+                self._check_empty_upstreams_on_startup()
 
     def _check_empty_upstreams_on_startup(self):
         empty_upstreams = [k for k, v in self._upstreams.items() if not v.servers]


### PR DESCRIPTION
Ссылка на портфель: https://jira.hh.ru/browse/PORTFOLIO-18027
Ссылка на задачу: https://jira.hh.ru/browse/HH-158763

Сейчас сервисы ходят в консул, и нет никакой возможности отслеживать результат этих походов (нет ни статистики, ни графиков, ни чего-то еще). В рамках выполнения данной задачи была добавлена отправка в окметр метрики consul.request, которая позволила бы мониторить результат выполнения запросов в консул. 
Для добавления отправки нужно было расширять функционал HttpClient'ов, являющихся частью форка python-consul2. Внутри команды решили, что не хочется увеличивать дифф между нашим форком и оригиналом. Решили, что будем наследоваться от базового HttpClient'а и копипастить нужные куски реализации. В [первом коммите](https://github.com/hhru/frontik/pull/563/commits/f53da52695e7c960dd0a20053eb9c9cb0d3b7523) как раз просто копипаста. Во [втором коммите](https://github.com/hhru/frontik/pull/563/commits/4d32f91bd0865023e04a35c87677643567812f66) уже добавлена обработка запросов в консул и отправка метрики. Причем отправка метрики в окметр осуществляется не сразу, а раз в какое-то время (для этого в statsDClient добавлены методы send_periodically и counters). Интервал отправки можно конфигурировать