### PR TITLE
HH-165972 convert async preprocessor to tornaado coroutine

### DIFF
--- a/tests/projects/test_app/pages/preprocessors/was_async_preprocessor_called.py
+++ b/tests/projects/test_app/pages/preprocessors/was_async_preprocessor_called.py
@@ -1,0 +1,36 @@
+from frontik.handler import PageHandler
+from frontik.preprocessors import preprocessor
+
+
+@preprocessor
+async def pp0(handler):
+    pass
+
+
+@preprocessor
+async def pp1(handler):
+    pass
+
+
+@preprocessor
+async def pp2(handler):
+    pass
+
+
+@preprocessor
+async def pp3(handler):
+    pass
+
+
+class Page(PageHandler):
+    preprocessors = [pp0]
+
+    @pp1
+    @pp2
+    def get_page(self):
+        self.json.put({
+            'pp0': self.was_preprocessor_called(pp0),
+            'pp1': self.was_preprocessor_called(pp1),
+            'pp2': self.was_preprocessor_called(pp2),
+            'pp3': self.was_preprocessor_called(pp3),
+        })

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -46,6 +46,18 @@ class TestPreprocessors(unittest.TestCase):
             }
         )
 
+    def test_was_async_preprocessor_called(self):
+        response_json = frontik_test_app.get_page_json('preprocessors/was_async_preprocessor_called')
+        self.assertEqual(
+            response_json,
+            {
+                'pp0': True,
+                'pp1': True,
+                'pp2': True,
+                'pp3': False,
+            }
+        )
+
     def test_priority_preprocessors(self):
         response_json = frontik_test_app.get_page_json('preprocessors/priority_preprocessors')
         self.assertEqual(


### PR DESCRIPTION
https://jira.hh.ru/browse/HH-165972

Добавил код оборачивающий async/await препроцессоры в торнадо корутины, для возможности их использования с существующим page handler'ом. Это подготовительный этап для перевода препроцессоров на async/await и выноса части из них в отдельный пакет.