### PR TITLE
HH-147490 add rid for logging_configurator_requests

### DIFF
--- a/frontik/loggers/logleveloverride/http_log_level_override_extension.py
+++ b/frontik/loggers/logleveloverride/http_log_level_override_extension.py
@@ -6,6 +6,7 @@ from tornado.httpclient import HTTPError
 
 from frontik.loggers.logleveloverride.log_level_override_extension import LogLevelOverrideExtension, LogLevelOverride
 from frontik.loggers.logleveloverride.logging_configurator_client import LOG_LEVEL_MAPPING
+from frontik import request_context
 
 logger = logging.getLogger('http_log_level_override_extension')
 
@@ -30,7 +31,10 @@ class HttpLogLevelOverrideExtension(LogLevelOverrideExtension):
         self.http_client_factory = http_client_factory
 
     async def load_log_level_overrides(self) -> List[LogLevelOverride]:
-        result = await self.http_client_factory.get_http_client().get_url(self.host, self.uri)
+        headers = {
+            'X-Request-Id': request_context.get_request_id()
+        }
+        result = await self.http_client_factory.get_http_client().get_url(self.host, self.uri, headers=headers)
         if result.failed:
             logger.error(f'some problem with fetching log level overrides: {result.failed}')
             raise HTTPError(result.response.code)


### PR DESCRIPTION
:arrow_right: **New code coverage** by unit tests| **N/A%**| [Sonar report](http://sonar.pyn.ru/dashboard?pullRequest=600&id=frontik)
--- | --- | ---
:arrow_right: **Code coverage** by unit tests| **0.0%**| 

https://jira.hh.ru/browse/HH-147490