### PR TITLE
HH-228148 make default router more visible; update docs

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,7 +1,12 @@
 ## Routing in Frontik applications
 
 On application start, frontik import all modules from {app_module}.pages so that any controller should be located there.
-We use fastapi routing, read [these docs](https://fastapi.tiangolo.com/reference/apirouter/?h=apirouter) for details. A small important difference - you must inherit `frontik.routing.FastAPIRouter` instead `fastapi.APIRouter`. And use `from frontik.routing import router`, if you need default router.
+We use fastapi routing, read [these docs](https://fastapi.tiangolo.com/reference/apirouter/?h=apirouter) for details.
+
+> [!IMPORTANT]
+> Never inherit from the `fastapi.APIRouter` router directly, instead you should use wrapped alternative from [`frontik.routing.FastAPIRouter`](https://github.com/hhru/frontik/blob/526a4cc22d151694fa48439f884dd03a6ca2329f/frontik/routing.py#L110)
+>
+> If you won't customize router behaviour then simply import `from frontik.routing import router`
 
 example:
 


### PR DESCRIPTION
- [x] **version change** <!--[MAJOR|MINOR|PATCH]-->: patch
- [x] **description**: 
  - renamed `frontik.routing.router` -> `frontik.routing.default_fastapi_router`; 
  - clarified docs on using our wrapper instead of fastapi router
- [x] **requires_changes_in_hh** <!-- [true|false] -->: -
- [x] **instructions** <!-- [if requires_changes_in_hh]-->: -
